### PR TITLE
Make WildcardManager.path a property

### DIFF
--- a/src/dynamicprompts/wildcardmanager.py
+++ b/src/dynamicprompts/wildcardmanager.py
@@ -18,6 +18,13 @@ class WildcardManager:
     def __init__(self, path: Path):
         self._path = path
 
+    @property
+    def path(self) -> Path:
+        """
+        The root path of the wildcard manager.
+        """
+        return self._path
+
     def _directory_exists(self) -> bool:
         return self._path.is_dir()
 

--- a/tests/prompts/test_wildcardmanager.py
+++ b/tests/prompts/test_wildcardmanager.py
@@ -1,6 +1,12 @@
 
 from dynamicprompts.wildcardmanager import WildcardManager
 
+from tests.conftest import WILDCARD_DATA_DIR
+
+
+def test_path(wildcard_manager: WildcardManager):
+    assert wildcard_manager.path == WILDCARD_DATA_DIR
+
 
 def test_is_wildcard(wildcard_manager: WildcardManager):
     assert wildcard_manager.is_wildcard("__test__")


### PR DESCRIPTION
The downstream sd library uses the private field; might just as well not