### PR TITLE
Magic prompt blocklist

### DIFF
--- a/src/dynamicprompts/generators/magicprompt.py
+++ b/src/dynamicprompts/generators/magicprompt.py
@@ -25,8 +25,8 @@ MAX_SEED = 2 ** 32 - 1
 def clean_up_magic_prompt(orig_prompt: str, prompt: str) -> str:
     # remove the original prompt to keep it out of the MP fixes
     removed_prompt_prefix = False
-    if re.search("^" + re.escape(orig_prompt), prompt):
-        prompt = prompt.replace(orig_prompt, "", 1)
+    if prompt.startswith(orig_prompt):
+        prompt = prompt[len(orig_prompt):]
         removed_prompt_prefix = True
 
     # old-style weight elevation

--- a/src/dynamicprompts/generators/magicprompt.py
+++ b/src/dynamicprompts/generators/magicprompt.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 
-from tqdm import trange
+import tqdm
 
 from dynamicprompts.generators.dummygenerator import DummyGenerator
 from dynamicprompts.generators.promptgenerator import PromptGenerator
@@ -133,12 +133,10 @@ class MagicPromptGenerator(PromptGenerator):
 
     def generate(self, *args, **kwargs) -> list[str]:
         prompts = self._prompt_generator.generate(*args, **kwargs)
-
-        new_prompts = []
-        for i in trange(len(prompts), desc="Generating Magic prompts"):
-            new_prompts.append(self._generate_magic_prompt(prompts[i]))
-
-        return new_prompts
+        return [
+            self._generate_magic_prompt(prompt)
+            for prompt in tqdm.tqdm(prompts, desc="Generating Magic Prompts")
+        ]
 
     def _generate_magic_prompt(self, orig_prompt: str, max_attempts: int = 20) -> str:
         prompt = orig_prompt  # Fallback

--- a/tests/prompts/generators/test_magicprompt.py
+++ b/tests/prompts/generators/test_magicprompt.py
@@ -1,5 +1,4 @@
 from functools import partial
-from unittest import mock
 
 import pytest
 
@@ -18,53 +17,55 @@ class TestMagicPrompt:
         CPU = -1
         assert generator._device == CPU
 
-    def test_cleanup_magic_prompt(self):
-        from dynamicprompts.generators.magicprompt import MagicPromptGenerator
-        #patch the load_pipeline method to return a mock generator
-        with mock.patch.object(MagicPromptGenerator, "_load_pipeline") as mock_load_pipeline:
-            mock_load_pipeline.return_value = mock.MagicMock()
-            magic_prompt_generator = MagicPromptGenerator(None, device=-1)
 
-            for original_prompt in ["Original prompt", "[Original|prompt]", "{Original|prompt}", "Original - prompt"]:
-                clean_up = partial(magic_prompt_generator.clean_up_magic_prompt, original_prompt)
+@pytest.mark.parametrize("original_prompt", [
+    "Original prompt",
+    "[Original|prompt]",
+    "{Original|prompt}",
+    "Original - prompt",
+])
+def test_cleanup_magic_prompt(original_prompt: str):
+    from dynamicprompts.generators.magicprompt import clean_up_magic_prompt
 
-                prompt = "- This is a {prompt} xyz"
-                cleaned_prompt = clean_up(original_prompt + " " + prompt)
-                assert cleaned_prompt == original_prompt + " This is a (prompt) xyz"
+    clean_up = partial(clean_up_magic_prompt, original_prompt)
 
-                prompt = " $$ This is a prompt $$"
-                cleaned_prompt =clean_up(original_prompt + " " + prompt)
-                assert cleaned_prompt == original_prompt + " This is a prompt"
+    prompt = "- This is a {prompt} xyz"
+    cleaned_prompt = clean_up(f"{original_prompt} {prompt}")
+    assert cleaned_prompt == f"{original_prompt} This is a (prompt) xyz"
 
-                prompt = "This ( is ) a prompt"
-                cleaned_prompt = clean_up(original_prompt + " " + prompt)
-                assert cleaned_prompt == original_prompt + " This (is) a prompt"
+    prompt = " $$ This is a prompt $$"
+    cleaned_prompt = clean_up(f"{original_prompt} {prompt}")
+    assert cleaned_prompt == f"{original_prompt} This is a prompt"
 
-                prompt = "This is - a prompt"
-                cleaned_prompt = clean_up(original_prompt + " " + prompt)
-                assert cleaned_prompt == original_prompt + " This is-a prompt"
+    prompt = "This ( is ) a prompt"
+    cleaned_prompt = clean_up(f"{original_prompt} {prompt}")
+    assert cleaned_prompt == f"{original_prompt} This (is) a prompt"
 
-                prompt = "This is a prompt; another prompt"
-                cleaned_prompt = clean_up(original_prompt + " " + prompt)
-                assert cleaned_prompt == original_prompt + " This is a prompt, another prompt"
+    prompt = "This is - a prompt"
+    cleaned_prompt = clean_up(f"{original_prompt} {prompt}")
+    assert cleaned_prompt == f"{original_prompt} This is-a prompt"
 
-                prompt = "This is. a prompt; another prompt"
-                cleaned_prompt = clean_up(original_prompt + " " + prompt)
-                assert cleaned_prompt == original_prompt + " This is, a prompt, another prompt"
+    prompt = "This is a prompt; another prompt"
+    cleaned_prompt = clean_up(f"{original_prompt} {prompt}")
+    assert cleaned_prompt == f"{original_prompt} This is a prompt, another prompt"
 
-                prompt = "This is a prompt _ another prompt"
-                cleaned_prompt = clean_up(original_prompt + prompt)
-                assert cleaned_prompt == original_prompt + " This is a prompt another prompt"
+    prompt = "This is. a prompt; another prompt"
+    cleaned_prompt = clean_up(f"{original_prompt} {prompt}")
+    assert cleaned_prompt == f"{original_prompt} This is, a prompt, another prompt"
 
-                # TODO
-                prompt = "This is a prompt , , another prompt"
-                cleaned_prompt = clean_up(original_prompt + " " + prompt)
-                assert cleaned_prompt == original_prompt + " This is a prompt ,, another prompt"
+    prompt = "This is a prompt _ another prompt"
+    cleaned_prompt = clean_up(f"{original_prompt}{prompt}")
+    assert cleaned_prompt == f"{original_prompt} This is a prompt another prompt"
 
-                prompt = "This is a prompt! dddd"
-                cleaned_prompt = clean_up(original_prompt + " " + prompt)
-                assert cleaned_prompt == original_prompt + " (This is a prompt:1.1) dddd"
+    # TODO
+    prompt = "This is a prompt , , another prompt"
+    cleaned_prompt = clean_up(f"{original_prompt} {prompt}")
+    assert cleaned_prompt == f"{original_prompt} This is a prompt ,, another prompt"
 
-                prompt = "This is a prompt!! dddd"
-                cleaned_prompt = clean_up(original_prompt + " " + prompt)
-                assert cleaned_prompt == original_prompt + " (This is a prompt:1.21) dddd"
+    prompt = "This is a prompt! dddd"
+    cleaned_prompt = clean_up(f"{original_prompt} {prompt}")
+    assert cleaned_prompt == f"{original_prompt} (This is a prompt:1.1) dddd"
+
+    prompt = "This is a prompt!! dddd"
+    cleaned_prompt = clean_up(f"{original_prompt} {prompt}")
+    assert cleaned_prompt == f"{original_prompt} (This is a prompt:1.21) dddd"

--- a/tests/prompts/generators/test_magicprompt.py
+++ b/tests/prompts/generators/test_magicprompt.py
@@ -1,3 +1,4 @@
+import random
 from functools import partial
 
 import pytest
@@ -69,3 +70,34 @@ def test_cleanup_magic_prompt(original_prompt: str):
     prompt = "This is a prompt!! dddd"
     cleaned_prompt = clean_up(f"{original_prompt} {prompt}")
     assert cleaned_prompt == f"{original_prompt} (This is a prompt:1.21) dddd"
+
+
+def test_magic_prompt_blocklist():
+    from dynamicprompts.generators.magicprompt import MagicPromptGenerator
+    boring_artists = [
+        "ertgarm",
+        "grug retkawsky",
+        "plow",
+    ]
+    all_artists = [
+        *boring_artists,
+        "akseli gallen-kallela",
+        "michael jackson",
+        "picasso",
+    ]
+
+    def _generator(orig_prompt: str, max_length: int, temperature: float):
+        return [{"generated_text": f"{orig_prompt} {random.choice(all_artists)}"}]
+
+    generator = MagicPromptGenerator(
+        # a regexp that will block some of those boring artists.
+        blocklist_regex=r"grug ret|plow|ertGa",
+    )
+    generator._generator = _generator
+
+    original_prompt = "This is a prompt"
+    for x in range(len(all_artists) * 2):  # should be enough to try things out
+        prompt = generator.generate(original_prompt)
+        assert prompt != original_prompt  # Make sure we're not getting the original prompt back
+        # Make sure we're not getting any of the blocked artists
+        assert not any(artist in prompt for artist in boring_artists)


### PR DESCRIPTION
This PR cleans up the magic prompt functionality a bit, then adds an option to enter a regexp to have the machinery re-try generating magic prompts that end up matching said regexp.

This is useful for blocking out e.g. certain terms or, as the example in the test shows, certain artists that tend to be a bit overrepresented in the usual magic prompt models and end up with "samey" output. 😁 