### PR TITLE
Reformat code with black and enable Ruff's comma rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.230
+    rev: v0.0.235
     hooks:
       - id: ruff
         args:
@@ -10,3 +10,9 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+      - id: black
+        args:
+          - --quiet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ target-version = "py37"
 select = [
     "B",
     "C",
+    "COM",
     "E",
     "F",
     "I",

--- a/src/dynamicprompts/generators/attentiongenerator.py
+++ b/src/dynamicprompts/generators/attentiongenerator.py
@@ -13,7 +13,10 @@ MODEL_NAME = "en_core_web_sm"
 
 class AttentionGenerator(PromptGenerator):
     def __init__(
-        self, generator: PromptGenerator | None = None, min_attention=0.1, max_attention=0.9
+        self,
+        generator: PromptGenerator | None = None,
+        min_attention=0.1,
+        max_attention=0.9,
     ):
         try:
             import spacy

--- a/src/dynamicprompts/generators/attentiongenerator.py
+++ b/src/dynamicprompts/generators/attentiongenerator.py
@@ -23,7 +23,7 @@ class AttentionGenerator(PromptGenerator):
         except ImportError as ie:
             raise ImportError(
                 "Could not import spacy, attention generator will not work. "
-                "Install with pip install dynamicprompts[attentiongrabber]"
+                "Install with pip install dynamicprompts[attentiongrabber]",
             ) from ie
         try:
             spacy.load(MODEL_NAME)

--- a/src/dynamicprompts/generators/combinatorial.py
+++ b/src/dynamicprompts/generators/combinatorial.py
@@ -14,9 +14,16 @@ logger = logging.getLogger(__name__)
 class CombinatorialPromptGenerator(PromptGenerator):
     def __init__(self, wildcard_manager: WildcardManager, ignore_whitespace=False):
         self._wildcard_manager = wildcard_manager
-        self._generator = CombinatorialGenerator(wildcard_manager, ignore_whitespace=ignore_whitespace)
+        self._generator = CombinatorialGenerator(
+            wildcard_manager,
+            ignore_whitespace=ignore_whitespace,
+        )
 
-    def generate(self, template, max_prompts:int|None=constants.MAX_IMAGES) -> Iterable[str]:
+    def generate(
+        self,
+        template,
+        max_prompts: int | None = constants.MAX_IMAGES,
+    ) -> Iterable[str]:
         if template is None or len(template) == 0:
             return [""]
         prompts = self._generator.generate_prompts(template, max_prompts)

--- a/src/dynamicprompts/generators/feelinglucky.py
+++ b/src/dynamicprompts/generators/feelinglucky.py
@@ -13,8 +13,9 @@ from dynamicprompts.generators.promptgenerator import (
 
 logger = logging.getLogger(__name__)
 
+
 class FeelingLuckyGenerator(PromptGenerator):
-    def __init__(self, generator: PromptGenerator|None=None):
+    def __init__(self, generator: PromptGenerator | None = None):
         if generator is None:
             self._generator = DummyGenerator()
         else:

--- a/src/dynamicprompts/generators/jinjagenerator.py
+++ b/src/dynamicprompts/generators/jinjagenerator.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 re_wildcard = re.compile(r"__(.*?)__")
 re_combinations = re.compile(r"\{([^{}]*)}")
 
+
 class RandomExtension(Extension):
     def __init__(self, environment):
         super().__init__(environment)
@@ -47,7 +48,7 @@ class PermutationExtension(Extension):
         super().__init__(environment)
         environment.globals["permutations"] = self.permutation
 
-    def permutation(self, items, low: int, high: int|None = None):
+    def permutation(self, items, low: int, high: int | None = None):
         vars = []
         if high is None:
             high = low
@@ -98,6 +99,7 @@ class PromptExtension(Extension):
         self.environment.prompt_blocks.append(caller())
         return caller()
 
+
 class JinjaGenerator(PromptGenerator):
     def __init__(self, wildcard_manager=None, context=None):
         self._wildcard_manager = wildcard_manager
@@ -107,14 +109,17 @@ class JinjaGenerator(PromptGenerator):
         else:
             self._context = {}
 
-
-    def generate(self, template: str, num_prompts: int=1) -> list[str]:
+    def generate(self, template: str, num_prompts: int = 1) -> list[str]:
         try:
             env = Environment(
-                extensions=[RandomExtension, PromptExtension, WildcardExtension, PermutationExtension]
+                extensions=[
+                    RandomExtension,
+                    PromptExtension,
+                    WildcardExtension,
+                    PermutationExtension,
+                ]
             )
             env.wildcard_manager = self._wildcard_manager
-
 
             prompts = []
             for i in range(num_prompts):

--- a/src/dynamicprompts/generators/jinjagenerator.py
+++ b/src/dynamicprompts/generators/jinjagenerator.py
@@ -92,7 +92,10 @@ class PromptExtension(Extension):
         lineno = next(parser.stream).lineno
         body = parser.parse_statements(["name:endprompt"], drop_needle=True)
         return jinja2.nodes.CallBlock(
-            self.call_method("_prompt", []), [], [], body
+            self.call_method("_prompt", []),
+            [],
+            [],
+            body,
         ).set_lineno(lineno)
 
     def _prompt(self, caller):
@@ -117,7 +120,7 @@ class JinjaGenerator(PromptGenerator):
                     PromptExtension,
                     WildcardExtension,
                     PermutationExtension,
-                ]
+                ],
             )
             env.wildcard_manager = self._wildcard_manager
 

--- a/src/dynamicprompts/generators/magicprompt.py
+++ b/src/dynamicprompts/generators/magicprompt.py
@@ -25,14 +25,14 @@ except ImportError as ie:
     ) from ie
 
 DEFAULT_MODEL_NAME = "Gustavosta/MagicPrompt-Stable-Diffusion"
-MAX_SEED = 2 ** 32 - 1
+MAX_SEED = 2**32 - 1
 
 
 def clean_up_magic_prompt(orig_prompt: str, prompt: str) -> str:
     # remove the original prompt to keep it out of the MP fixes
     removed_prompt_prefix = False
     if prompt.startswith(orig_prompt):
-        prompt = prompt[len(orig_prompt):]
+        prompt = prompt[len(orig_prompt) :]
         removed_prompt_prefix = True
 
     # old-style weight elevation
@@ -83,7 +83,10 @@ class MagicPromptGenerator(PromptGenerator):
             MagicPromptGenerator.tokenizer = tokenizer
             MagicPromptGenerator.model = model
             MagicPromptGenerator.generator = pipeline(
-                task="text-generation", tokenizer=tokenizer, model=model, device=self._device
+                task="text-generation",
+                tokenizer=tokenizer,
+                model=model,
+                device=self._device,
             )
             MagicPromptGenerator._model_name = model_name
 

--- a/src/dynamicprompts/generators/magicprompt.py
+++ b/src/dynamicprompts/generators/magicprompt.py
@@ -21,7 +21,7 @@ try:
 except ImportError as ie:
     raise ImportError(
         "You need to install the transformers library to use the MagicPrompt generator. "
-        "You can do this by running `pip install -U dynamicprompts[magicprompt]`."
+        "You can do this by running `pip install -U dynamicprompts[magicprompt]`.",
     ) from ie
 
 DEFAULT_MODEL_NAME = "Gustavosta/MagicPrompt-Stable-Diffusion"
@@ -156,12 +156,12 @@ class MagicPromptGenerator(PromptGenerator):
                 if match:
                     logger.info(
                         f"Generated magic prompt '{prompt}' blocked: "
-                        f"'{match.group(0)}' matched blocklist regex."
+                        f"'{match.group(0)}' matched blocklist regex.",
                     )
                     continue
             return prompt
         logger.warning(
             f"Failed to generate non-blocked magic prompt for '{orig_prompt}' after {max_attempts} attempts. "
-            f"Will still use last generated magic prompt."
+            f"Will still use last generated magic prompt.",
         )
         return prompt

--- a/src/dynamicprompts/generators/randomprompt.py
+++ b/src/dynamicprompts/generators/randomprompt.py
@@ -10,13 +10,14 @@ from dynamicprompts.wildcardmanager import WildcardManager
 
 logger = logging.getLogger(__name__)
 
+
 class RandomPromptGenerator(PromptGenerator):
     def __init__(
         self,
         wildcard_manager: WildcardManager,
         seed: int | None = None,
         unlink_seed_from_prompt: bool = False,
-        ignore_whitespace=False
+        ignore_whitespace=False,
     ):
         self._wildcard_manager = wildcard_manager
         self._unlink_seed_from_prompt = unlink_seed_from_prompt
@@ -28,7 +29,11 @@ class RandomPromptGenerator(PromptGenerator):
             if seed is not None:
                 self._random.seed(seed)
 
-        self._generator = RandomGenerator(wildcard_manager, rand=self._random, ignore_whitespace=ignore_whitespace)
+        self._generator = RandomGenerator(
+            wildcard_manager,
+            rand=self._random,
+            ignore_whitespace=ignore_whitespace,
+        )
 
     def generate(self, template, num_images=1) -> list[str]:
         if template is None or len(template) == 0:

--- a/src/dynamicprompts/parser/action_builder.py
+++ b/src/dynamicprompts/parser/action_builder.py
@@ -64,7 +64,8 @@ class ActionBuilder:
         variants = [{"weight": v["weight"], "val": v["val"]} for v in variants]
         if "bound_expr" in parts:
             min_bound, max_bound, sep = parse_bound_expr(
-                parts["bound_expr"], max_options=len(variants)
+                parts["bound_expr"],
+                max_options=len(variants),
             )
             command = self.create_variant_command(variants, min_bound, max_bound, sep)
         else:

--- a/src/dynamicprompts/parser/combinatorial_generator.py
+++ b/src/dynamicprompts/parser/combinatorial_generator.py
@@ -139,7 +139,9 @@ class CombinatorialGenerator:
         return parser
 
     def generate_prompts(
-        self, prompt: str, num_prompts: int | None = None
+        self,
+        prompt: str,
+        num_prompts: int | None = None,
     ) -> Iterable[str]:
         if len(prompt) == 0:
             return []

--- a/src/dynamicprompts/parser/combinatorial_generator.py
+++ b/src/dynamicprompts/parser/combinatorial_generator.py
@@ -19,7 +19,11 @@ from dynamicprompts.wildcardmanager import WildcardManager
 
 
 class CombinatorialSequenceCommand(SequenceCommand):
-    def __init__(self, tokens: list[Command] | None = None, separator=""):
+    def __init__(
+        self,
+        tokens: list[Command] | None = None,
+        separator="",
+    ):
         self._sep = separator
         super().__init__(tokens)
 
@@ -38,7 +42,12 @@ class CombinatorialSequenceCommand(SequenceCommand):
 
 
 class CombinatorialWildcardCommand(WildcardCommand):
-    def __init__(self, wildcard_manager: WildcardManager, builder: ActionBuilder, token):
+    def __init__(
+        self,
+        wildcard_manager: WildcardManager,
+        builder: ActionBuilder,
+        token,
+    ):
         super().__init__(wildcard_manager, token)
         self._wildcard_manager = wildcard_manager
         self._wildcard = token[0]
@@ -106,7 +115,11 @@ class CombinatorialActionBuilder(ActionBuilder):
         return CombinatorialSequenceCommand(token_list)
 
     def create_generator(self):
-        return CombinatorialGenerator(self._wildcard_manager, ignore_whitespace=self._ignore_whitespace)
+        return CombinatorialGenerator(
+            self._wildcard_manager,
+            ignore_whitespace=self._ignore_whitespace,
+        )
+
 
 class CombinatorialGenerator:
     def __init__(self, wildcard_manager, ignore_whitespace=False):
@@ -114,7 +127,10 @@ class CombinatorialGenerator:
         self._ignore_whitespace = ignore_whitespace
 
     def get_action_builder(self) -> ActionBuilder:
-        return CombinatorialActionBuilder(self._wildcard_manager, self._ignore_whitespace)
+        return CombinatorialActionBuilder(
+            self._wildcard_manager,
+            self._ignore_whitespace,
+        )
 
     def configure_parser(self) -> Parser:
         builder = self.get_action_builder()

--- a/src/dynamicprompts/parser/parse.py
+++ b/src/dynamicprompts/parser/parse.py
@@ -44,7 +44,7 @@ class Parser:
         variant_delim = pp.Suppress("$$")
 
         separator = pp.Word(pp.alphanums + " ", exclude_chars="$")(
-            "separator"
+            "separator",
         ).leave_whitespace()
 
         bound = pp.common.integer
@@ -54,12 +54,12 @@ class Parser:
         bound_range4 = bound("lower") + hyphen + bound("upper")
 
         bound_range = pp.Group(
-            bound_range4 | bound_range3 | bound_range2 | bound_range1
+            bound_range4 | bound_range3 | bound_range2 | bound_range1,
         )
         bound_expr = pp.Group(
             bound_range("range")
             + variant_delim
-            + pp.Opt(separator + variant_delim, default=",")("separator")
+            + pp.Opt(separator + variant_delim, default=",")("separator"),
         )
 
         return bound_expr
@@ -77,7 +77,7 @@ class Parser:
             non_literal_chars = r"{}$#"
 
         literal = pp.Regex(rf"((?!{double_underscore})[^{non_literal_chars}])+")(
-            "literal"
+            "literal",
         ).leave_whitespace()
         literal_sequence = pp.OneOrMore(literal)
 
@@ -114,7 +114,7 @@ class Parser:
         wildcard = self._configure_wildcard()
         literal_sequence = self._configure_literal_sequence()
         variant_literal_sequence = self._configure_literal_sequence(
-            is_variant_literal=True
+            is_variant_literal=True,
         )
         variants = self._configure_variants(bound_expr, variant_prompt)
 

--- a/src/dynamicprompts/parser/random_generator.py
+++ b/src/dynamicprompts/parser/random_generator.py
@@ -90,26 +90,51 @@ class RandomVariantCommand(Command):
 
 
 class RandomActionBuilder(ActionBuilder):
-    def __init__(self, wildcard_manager: WildcardManager, rand=None, seq_sep="", ignore_whitespace=False):
+    def __init__(
+        self,
+        wildcard_manager: WildcardManager,
+        rand=None,
+        seq_sep="",
+        ignore_whitespace=False,
+    ):
         super().__init__(wildcard_manager, ignore_whitespace=ignore_whitespace)
         self._seq_sep = seq_sep
         self._random = rand or random
 
     def create_variant_command(self, variants, min_bound=1, max_bound=1, sep=","):
-        return RandomVariantCommand(variants, min_bound, max_bound, sep, rand=self._random)
+        return RandomVariantCommand(
+            variants,
+            min_bound,
+            max_bound,
+            sep,
+            rand=self._random,
+        )
 
     def create_wildcard_command(self, token: str):
-        return RandomWildcardCommand(self._wildcard_manager, self, token, rand=self._random)
+        return RandomWildcardCommand(
+            self._wildcard_manager,
+            self,
+            token,
+            rand=self._random,
+        )
 
     def create_sequence_command(self, token_list: list[Command]):
         return RandomSequenceCommand(token_list, separator=self._seq_sep)
 
     def create_generator(self):
-        return RandomGenerator(self._wildcard_manager, ignore_whitespace=self._ignore_whitespace)
+        return RandomGenerator(
+            self._wildcard_manager,
+            ignore_whitespace=self._ignore_whitespace,
+        )
 
 
 class RandomGenerator:
-    def __init__(self, wildcard_manager: WildcardManager, rand=None, ignore_whitespace=False):
+    def __init__(
+        self,
+        wildcard_manager: WildcardManager,
+        rand=None,
+        ignore_whitespace=False,
+    ):
         if rand is None:
             self._random = random
         else:
@@ -118,7 +143,12 @@ class RandomGenerator:
         self._ignore_whitespace = ignore_whitespace
 
     def get_action_builder(self) -> ActionBuilder:
-        return RandomActionBuilder(self._wildcard_manager, seq_sep="", ignore_whitespace=self._ignore_whitespace, rand=self._random)
+        return RandomActionBuilder(
+            self._wildcard_manager,
+            seq_sep="",
+            ignore_whitespace=self._ignore_whitespace,
+            rand=self._random,
+        )
 
     def configure_parser(self):
         builder = self.get_action_builder()
@@ -139,7 +169,6 @@ class RandomGenerator:
             return []
 
         for i in range(num_prompts):
-
 
             prompts = list(tokens[0].prompts())
             if len(prompts) == 0:

--- a/src/dynamicprompts/wildcardmanager.py
+++ b/src/dynamicprompts/wildcardmanager.py
@@ -78,7 +78,7 @@ class WildcardManager:
 
     def wildcard_to_path(self, wildcard: str) -> Path:
         return (self._path / _clean_wildcard(wildcard)).with_suffix(
-            f".{constants.WILDCARD_SUFFIX}"
+            f".{constants.WILDCARD_SUFFIX}",
         )
 
     def path_to_wildcard(self, path: Path) -> str:

--- a/src/dynamicprompts/wildcardmanager.py
+++ b/src/dynamicprompts/wildcardmanager.py
@@ -22,7 +22,8 @@ def _is_relative_to(p1: Path, p2: Path) -> bool:
 def _clean_wildcard(wildcard: str):
     wildcard = (
         wildcard.strip("_")  # remove wildcard delimiters
-        .replace("/", os.sep).replace("\\", os.sep)  # normalize path separators
+        .replace("/", os.sep)
+        .replace("\\", os.sep)  # normalize path separators
         .rstrip(os.sep)  # remove trailing path separator (likely a typo)
     )
     if wildcard.startswith(os.sep):

--- a/tests/prompts/generators/randomprompt/conftest.py
+++ b/tests/prompts/generators/randomprompt/conftest.py
@@ -16,5 +16,8 @@ def seed() -> int:
 @pytest.fixture
 def generator(wildcard_manager: WildcardManager, seed: int) -> RandomPromptGenerator:
     return RandomPromptGenerator(
-        wildcard_manager, "A template", seed=seed, unlink_seed_from_prompt=False
+        wildcard_manager,
+        "A template",
+        seed=seed,
+        unlink_seed_from_prompt=False,
     )

--- a/tests/prompts/generators/randomprompt/test_unlink_seed.py
+++ b/tests/prompts/generators/randomprompt/test_unlink_seed.py
@@ -11,7 +11,9 @@ class TestUnlinkSeedFromPrompt:
 
         for i in range(5):
             generator = RandomPromptGenerator(
-                wildcard_manager, unlink_seed_from_prompt=False, seed=0
+                wildcard_manager,
+                unlink_seed_from_prompt=False,
+                seed=0,
             )
             prompt = "I love {1-2$$red|green|blue}"
 

--- a/tests/prompts/generators/randomprompt/test_unlink_seed.py
+++ b/tests/prompts/generators/randomprompt/test_unlink_seed.py
@@ -1,10 +1,12 @@
-
 from dynamicprompts.generators.randomprompt import RandomPromptGenerator
 
 
 class TestUnlinkSeedFromPrompt:
     def test_no_unlink_seed_from_prompt(self, wildcard_manager):
-        generator = RandomPromptGenerator(wildcard_manager, unlink_seed_from_prompt=False)
+        generator = RandomPromptGenerator(
+            wildcard_manager,
+            unlink_seed_from_prompt=False,
+        )
         assert generator._unlink_seed_from_prompt is False
 
         for i in range(5):
@@ -17,17 +19,26 @@ class TestUnlinkSeedFromPrompt:
             first_prompts = prompts
 
             for i in range(10):
-                generator = RandomPromptGenerator(wildcard_manager, unlink_seed_from_prompt=False, seed=0)
+                generator = RandomPromptGenerator(
+                    wildcard_manager,
+                    unlink_seed_from_prompt=False,
+                    seed=0,
+                )
                 prompts = list(generator.generate(prompt, 5))
                 assert prompts == first_prompts
 
     def test_unlink_seed_from_prompt(self, wildcard_manager):
-        generator = RandomPromptGenerator(wildcard_manager, unlink_seed_from_prompt=True)
+        generator = RandomPromptGenerator(
+            wildcard_manager,
+            unlink_seed_from_prompt=True,
+        )
         assert generator._unlink_seed_from_prompt is True
 
         for i in range(5):
             generator = RandomPromptGenerator(
-                wildcard_manager, unlink_seed_from_prompt=True, seed=0
+                wildcard_manager,
+                unlink_seed_from_prompt=True,
+                seed=0,
             )
             prompt = "I love {1-2$$red|green|blue}"
 
@@ -35,6 +46,10 @@ class TestUnlinkSeedFromPrompt:
             first_prompts = prompts
 
             for i in range(10):
-                generator = RandomPromptGenerator(wildcard_manager, unlink_seed_from_prompt=True, seed=0)
+                generator = RandomPromptGenerator(
+                    wildcard_manager,
+                    unlink_seed_from_prompt=True,
+                    seed=0,
+                )
                 prompts = list(generator.generate(prompt, 20))
                 assert prompts != first_prompts

--- a/tests/prompts/generators/test_combinatorial.py
+++ b/tests/prompts/generators/test_combinatorial.py
@@ -33,7 +33,6 @@ class TestCombinatorialGenerator:
         assert prompts[1] == "I love butter"
         assert prompts[2] == "I love cheese"
 
-
         prompts = list(generator.generate(prompt, 2))
 
         assert len(prompts) == 2

--- a/tests/prompts/generators/test_extensions.py
+++ b/tests/prompts/generators/test_extensions.py
@@ -10,7 +10,7 @@ class TestRandomExtension:
     def test_choice(self):
         ext = RandomExtension(mock.MagicMock())
 
-        with mock.patch('random.choice') as mock_choice:
+        with mock.patch("random.choice") as mock_choice:
             mock_choice.side_effect = "c"
             res = ext.choice("a", "b", "c")
             assert res == "c"
@@ -18,7 +18,7 @@ class TestRandomExtension:
     def test_random(self):
         ext = RandomExtension(mock.MagicMock())
 
-        with mock.patch('random.random') as mock_random:
+        with mock.patch("random.random") as mock_random:
             mock_random.return_value = 0.3
             res = ext.random()
             assert res == 0.3
@@ -26,10 +26,11 @@ class TestRandomExtension:
     def test_randint(self):
         ext = RandomExtension(mock.MagicMock())
 
-        with mock.patch('random.randint') as mock_random:
+        with mock.patch("random.randint") as mock_random:
             mock_random.return_value = 7
             res = ext.randint(1, 10)
             assert res == 7
+
 
 class TestPermutationExtension:
     def test_basic_permutation(self):
@@ -37,24 +38,24 @@ class TestPermutationExtension:
         res = ext.permutation(["one", "two", "three"], 2)
 
         assert len(res) == 6
-        assert res[0] == ("one", "two" )
-        assert res[1] == ("one", "three" )
-        assert res[2] == ("two", "one" )
-        assert res[3] == ("two", "three" )
-        assert res[4] == ("three", "one" )
-        assert res[5] == ("three", "two" )
+        assert res[0] == ("one", "two")
+        assert res[1] == ("one", "three")
+        assert res[2] == ("two", "one")
+        assert res[3] == ("two", "three")
+        assert res[4] == ("three", "one")
+        assert res[5] == ("three", "two")
 
     def test_permutation(self):
         ext = PermutationExtension(mock.MagicMock())
         res = ext.permutation(["one", "two", "three"], 1, 2)
 
         assert len(res) == 9
-        assert res[0] == ("one", )
-        assert res[1] == ("two", )
-        assert res[2] == ("three", )
-        assert res[3] == ("one", "two" )
-        assert res[4] == ("one", "three" )
-        assert res[5] == ("two", "one" )
-        assert res[6] == ("two", "three" )
-        assert res[7] == ("three", "one" )
-        assert res[8] == ("three", "two" )
+        assert res[0] == ("one",)
+        assert res[1] == ("two",)
+        assert res[2] == ("three",)
+        assert res[3] == ("one", "two")
+        assert res[4] == ("one", "three")
+        assert res[5] == ("two", "one")
+        assert res[6] == ("two", "three")
+        assert res[7] == ("three", "one")
+        assert res[8] == ("three", "two")

--- a/tests/prompts/generators/test_feelinglucky.py
+++ b/tests/prompts/generators/test_feelinglucky.py
@@ -10,21 +10,24 @@ class TestFeelingLucky:
 
     def test_generate(self):
         results = [{"prompt": "ABC"}, {"prompt": "XYZ"}]
-        with mock.patch("dynamicprompts.generators.feelinglucky.requests") as mock_response:
-            with mock.patch("dynamicprompts.generators.feelinglucky.random") as mock_random:
-                mock_generator = mock.Mock()
-                mock_generator.generate.return_value = ["Prompt"]
+        with mock.patch(
+            "dynamicprompts.generators.feelinglucky.requests"
+        ) as mock_response, mock.patch(
+            "dynamicprompts.generators.feelinglucky.random"
+        ) as mock_random:
+            mock_generator = mock.Mock()
+            mock_generator.generate.return_value = ["Prompt"]
 
-                m = mock.Mock()
-                m.json.return_value = {"images": results}
-                mock_response.get.return_value = m
-                mock_random.choices.return_value = [results[0]]
+            m = mock.Mock()
+            m.json.return_value = {"images": results}
+            mock_response.get.return_value = m
+            mock_random.choices.return_value = [results[0]]
 
-                generator = FeelingLuckyGenerator(mock_generator)
-                prompts = generator.generate("This is a test", 1)
-                assert len(prompts) == 1
-                assert prompts[0] == results[0]["prompt"]
+            generator = FeelingLuckyGenerator(mock_generator)
+            prompts = generator.generate("This is a test", 1)
+            assert len(prompts) == 1
+            assert prompts[0] == results[0]["prompt"]
 
-                mock_generator.generate.assert_called_with("This is a test", 1)
+            mock_generator.generate.assert_called_with("This is a test", 1)
 
-                mock_random.choices.assert_called_with(results, k=1)
+            mock_random.choices.assert_called_with(results, k=1)

--- a/tests/prompts/generators/test_feelinglucky.py
+++ b/tests/prompts/generators/test_feelinglucky.py
@@ -11,9 +11,9 @@ class TestFeelingLucky:
     def test_generate(self):
         results = [{"prompt": "ABC"}, {"prompt": "XYZ"}]
         with mock.patch(
-            "dynamicprompts.generators.feelinglucky.requests"
+            "dynamicprompts.generators.feelinglucky.requests",
         ) as mock_response, mock.patch(
-            "dynamicprompts.generators.feelinglucky.random"
+            "dynamicprompts.generators.feelinglucky.random",
         ) as mock_random:
             mock_generator = mock.Mock()
             mock_generator.generate.return_value = ["Prompt"]

--- a/tests/prompts/generators/test_jinja.py
+++ b/tests/prompts/generators/test_jinja.py
@@ -5,6 +5,8 @@ from dynamicprompts.generators.jinjagenerator import JinjaGenerator
 from dynamicprompts.generators.promptgenerator import GeneratorException
 from dynamicprompts.wildcardmanager import WildcardManager
 
+GET_ALL_VALUES = "dynamicprompts.wildcardmanager.WildcardManager.get_all_values"
+
 
 @pytest.fixture
 def generator(wildcard_manager: WildcardManager):
@@ -20,7 +22,7 @@ class TestJinjaGenerator:
         assert prompts[0] == template
 
     def test_choice_prompt(self, generator):
-        with patch('random.choice') as mock_choice:
+        with patch("random.choice") as mock_choice:
             mock_choice.side_effect = ["red", "blue", "red"]
             template = "This is a {{ choice('red', 'blue') }} rose"
 
@@ -32,7 +34,7 @@ class TestJinjaGenerator:
             assert prompts[2] == "This is a red rose"
 
     def test_two_choice_prompt(self, generator):
-        with patch('random.choice') as mock_choice:
+        with patch("random.choice") as mock_choice:
             mock_choice.side_effect = ["red", "triangle", "blue", "square"]
             template = "This is a {{ choice('red', 'blue') }} {{ choice('triangle', 'square') }}"
             prompts = generator.generate(template, 2)
@@ -92,10 +94,10 @@ class TestJinjaGenerator:
         {% endfor %}
         """
 
-        with patch('dynamicprompts.wildcardmanager.WildcardManager.get_all_values') as mock_values:
+        with patch(GET_ALL_VALUES) as mock_values:
             mock_values.side_effect = (
                 ["pink", "yellow", "__blacks__", "purple"],
-                ["black", "grey"]
+                ["black", "grey"],
             )
 
             prompts = generator.generate(template)
@@ -114,12 +116,11 @@ class TestJinjaGenerator:
         {% endfor %}
         """
 
-        with patch('dynamicprompts.wildcardmanager.WildcardManager.get_all_values') as mock_values:
+        with patch(GET_ALL_VALUES) as mock_values:
             mock_values.side_effect = (
                 ["pink", "yellow", "__blacks__", "purple"],
                 ["black", "__greys__"],
                 ["light grey", "dark grey"],
-
             )
 
             prompts = generator.generate(template)
@@ -139,12 +140,10 @@ class TestJinjaGenerator:
         {% endfor %}
         """
 
-        with patch('dynamicprompts.wildcardmanager.WildcardManager.get_all_values') as mock_values:
-            mock_values.side_effect = (
-                ["pink", "yellow", "{white|black}", "purple"],
-            )
+        with patch(GET_ALL_VALUES) as mock_values:
+            mock_values.side_effect = (["pink", "yellow", "{white|black}", "purple"],)
 
-            with patch('random.choice') as mock_choice:
+            with patch("random.choice") as mock_choice:
                 mock_choice.return_value = "white"
 
                 prompts = generator.generate(template)
@@ -160,7 +159,7 @@ class TestJinjaGenerator:
         {% prompt %}My favourite colour is {{ choice(wildcard("__colours__")) }}{% endprompt %}
         """
 
-        with patch('random.choice') as mock_choice:
+        with patch("random.choice") as mock_choice:
             mock_choice.return_value = "yellow"
 
             prompts = generator.generate(template)
@@ -178,7 +177,7 @@ class TestJinjaGenerator:
             generator.generate(template)
 
     def test_random(self, generator):
-        with patch('random.random') as mock_choice:
+        with patch("random.random") as mock_choice:
             mock_choice.return_value = 0.3
             template = """
             {% prompt %}My favourite number is {{ random() }}{% endprompt %}
@@ -190,7 +189,7 @@ class TestJinjaGenerator:
             assert prompts[0] == "My favourite number is 0.3"
 
     def test_weighted_choice(self, generator):
-        with patch('random.choices') as mock_choice:
+        with patch("random.choices") as mock_choice:
             mock_choice.side_effect = [["yellow"]]
             template = """My favourite colour is {{ weighted_choice(("pink", 0.2), ("yellow", 0.3), ("black", 0.4), ("purple", 0.1)) }}"""
 

--- a/tests/prompts/generators/test_magicprompt.py
+++ b/tests/prompts/generators/test_magicprompt.py
@@ -19,12 +19,15 @@ class TestMagicPrompt:
         assert generator._device == CPU
 
 
-@pytest.mark.parametrize("original_prompt", [
-    "Original prompt",
-    "[Original|prompt]",
-    "{Original|prompt}",
-    "Original - prompt",
-])
+@pytest.mark.parametrize(
+    "original_prompt",
+    [
+        "Original prompt",
+        "[Original|prompt]",
+        "{Original|prompt}",
+        "Original - prompt",
+    ],
+)
 def test_cleanup_magic_prompt(original_prompt: str):
     from dynamicprompts.generators.magicprompt import clean_up_magic_prompt
 
@@ -75,6 +78,7 @@ def test_cleanup_magic_prompt(original_prompt: str):
 @pytest.mark.slow
 def test_magic_prompt_blocklist():
     from dynamicprompts.generators.magicprompt import MagicPromptGenerator
+
     boring_artists = [
         "ertgarm",
         "grug retkawsky",
@@ -99,6 +103,8 @@ def test_magic_prompt_blocklist():
     original_prompt = "This is a prompt"
     for x in range(len(all_artists) * 2):  # should be enough to try things out
         prompt = generator.generate(original_prompt)
-        assert prompt != original_prompt  # Make sure we're not getting the original prompt back
+        assert (
+            prompt != original_prompt
+        )  # Make sure we're not getting the original prompt back
         # Make sure we're not getting any of the blocked artists
         assert not any(artist in prompt for artist in boring_artists)

--- a/tests/prompts/parser/test_action_builder.py
+++ b/tests/prompts/parser/test_action_builder.py
@@ -13,9 +13,11 @@ from dynamicprompts.parser.commands import (
 def wildcard_manager():
     return mock.Mock()
 
+
 @pytest.fixture
 def action_builder(wildcard_manager):
     return ActionBuilder(wildcard_manager)
+
 
 class TestActionBuilder:
     def test_literal_action(self, action_builder: ActionBuilder):
@@ -41,7 +43,12 @@ class TestActionBuilder:
     #     assert isinstance(variant_action, VariantCommand)
 
     def test_sequence_action(self, action_builder: ActionBuilder):
-        commands = [LiteralCommand("A"), LiteralCommand("string"), LiteralCommand("of"), LiteralCommand("tokens")]
+        commands = [
+            LiteralCommand("A"),
+            LiteralCommand("string"),
+            LiteralCommand("of"),
+            LiteralCommand("tokens"),
+        ]
         sequence = action_builder.get_sequence_action(commands)
         assert isinstance(sequence, SequenceCommand)
         assert len(sequence) == 4

--- a/tests/prompts/parser/test_combinatorial_generator.py
+++ b/tests/prompts/parser/test_combinatorial_generator.py
@@ -19,9 +19,11 @@ def wildcard_manager():
 def generator(wildcard_manager) -> CombinatorialGenerator:
     return CombinatorialGenerator(wildcard_manager)
 
+
 @pytest.fixture
 def builder(wildcard_manager) -> CombinatorialActionBuilder:
     return CombinatorialActionBuilder(wildcard_manager)
+
 
 def gen_variant(vals):
     return [{"weight": [1], "val": LiteralCommand(v)} for v in vals]
@@ -172,7 +174,9 @@ class TestVariantCommand:
 class TestWildcardsCommand:
     def test_basic_wildcard(self, builder: CombinatorialActionBuilder):
         with mock.patch.object(
-            builder._wildcard_manager, "get_all_values", return_value=["red", "green", "blue"]
+            builder._wildcard_manager,
+            "get_all_values",
+            return_value=["red", "green", "blue"],
         ):
             command = builder.get_wildcard_action(["colours"])
             prompts = list(command.prompts())
@@ -185,7 +189,9 @@ class TestWildcardsCommand:
 
     def test_wildcard_with_literal(self, builder: CombinatorialActionBuilder):
         with mock.patch.object(
-            builder._wildcard_manager, "get_all_values", return_value=["red", "green", "blue"]
+            builder._wildcard_manager,
+            "get_all_values",
+            return_value=["red", "green", "blue"],
         ):
             command1 = builder.get_wildcard_action(["colours"])
             command2 = builder.get_literal_action(" are cool")
@@ -200,7 +206,9 @@ class TestWildcardsCommand:
 
     def test_wildcard_with_variant(self, builder: CombinatorialActionBuilder):
         with mock.patch.object(
-            builder._wildcard_manager, "get_all_values", return_value=["red", "green", "blue"]
+            builder._wildcard_manager,
+            "get_all_values",
+            return_value=["red", "green", "blue"],
         ):
 
             command1 = builder.get_wildcard_action("colours")
@@ -344,7 +352,9 @@ class TestCombinatorialGenerator:
     def test_combination_variants_with_separator(
         self, generator: CombinatorialGenerator
     ):
-        prompts = list(generator.generate_prompts("A {2$$ and $$red|green|blue} square", 10))
+        prompts = list(
+            generator.generate_prompts("A {2$$ and $$red|green|blue} square", 10)
+        )
         assert len(prompts) == 6
         assert prompts[0] == "A red and green square"
         assert prompts[1] == "A red and blue square"
@@ -370,7 +380,9 @@ class TestCombinatorialGenerator:
             "get_all_values",
             return_value=["red", "green", "blue"],
         ):
-            prompts = list(generator.generate_prompts("A __colours__ {square|circle}", 6))
+            prompts = list(
+                generator.generate_prompts("A __colours__ {square|circle}", 6)
+            )
             assert len(prompts) == 6
             assert prompts[0] == "A red square"
             assert prompts[1] == "A red circle"

--- a/tests/prompts/parser/test_combinatorial_generator.py
+++ b/tests/prompts/parser/test_combinatorial_generator.py
@@ -42,7 +42,7 @@ class TestLiteralCommand:
         command3 = LiteralCommand("three")
         space = LiteralCommand(" ")
         sequence = CombinatorialSequenceCommand(
-            [command1, space, command2, space, command3]
+            [command1, space, command2, space, command3],
         )
 
         prompts = list(sequence.prompts())
@@ -350,10 +350,11 @@ class TestCombinatorialGenerator:
         assert prompts[8] == "A blue,green square"
 
     def test_combination_variants_with_separator(
-        self, generator: CombinatorialGenerator
+        self,
+        generator: CombinatorialGenerator,
     ):
         prompts = list(
-            generator.generate_prompts("A {2$$ and $$red|green|blue} square", 10)
+            generator.generate_prompts("A {2$$ and $$red|green|blue} square", 10),
         )
         assert len(prompts) == 6
         assert prompts[0] == "A red and green square"
@@ -364,7 +365,8 @@ class TestCombinatorialGenerator:
         assert prompts[5] == "A blue and green square"
 
     def test_variants_with_larger_range_than_choices(
-        self, generator: CombinatorialGenerator
+        self,
+        generator: CombinatorialGenerator,
     ):
         shapes = ["square", "circle"]
         with mock.patch("dynamicprompts.parser.random_generator.random") as mock_random:
@@ -381,7 +383,7 @@ class TestCombinatorialGenerator:
             return_value=["red", "green", "blue"],
         ):
             prompts = list(
-                generator.generate_prompts("A __colours__ {square|circle}", 6)
+                generator.generate_prompts("A __colours__ {square|circle}", 6),
             )
             assert len(prompts) == 6
             assert prompts[0] == "A red square"
@@ -391,7 +393,7 @@ class TestCombinatorialGenerator:
             assert prompts[4] == "A blue square"
             assert prompts[5] == "A blue circle"
             generator._wildcard_manager.get_all_values.assert_called_once_with(
-                "colours"
+                "colours",
             )
 
     def test_nested_wildcard(self, generator: CombinatorialGenerator):
@@ -419,7 +421,8 @@ class TestCombinatorialGenerator:
             assert prompts[5] == "blue,green"
 
     def test_nested_wildcard_with_range_and_literal(
-        self, generator: CombinatorialGenerator
+        self,
+        generator: CombinatorialGenerator,
     ):
         with mock.patch.object(
             generator._wildcard_manager,

--- a/tests/prompts/parser/test_commands.py
+++ b/tests/prompts/parser/test_commands.py
@@ -94,12 +94,16 @@ class TestVariant:
     def test_range(self):
         literals = ["one", "two", "three"]
         variant_command = VariantCommand(
-            gen_variant(literals), min_bound=-1, max_bound=10
+            gen_variant(literals),
+            min_bound=-1,
+            max_bound=10,
         )
         assert variant_command.min_bound == 1
 
         variant_command = VariantCommand(
-            gen_variant(literals), min_bound=2, max_bound=1
+            gen_variant(literals),
+            min_bound=2,
+            max_bound=1,
         )
         assert variant_command.min_bound == 1
         assert variant_command.max_bound == 2

--- a/tests/prompts/parser/test_parser.py
+++ b/tests/prompts/parser/test_parser.py
@@ -179,7 +179,7 @@ class TestParser:
     def test_variant_sequences(self, parser: Parser):
 
         sequence = parser.parse(
-            "{My favourite colour is __colour__ and not __other_colour__|__colour__ is my favourite colour}"
+            "{My favourite colour is __colour__ and not __other_colour__|__colour__ is my favourite colour}",
         )
         assert len(sequence) == 1
         assert type(sequence[0]) == VariantCommand

--- a/tests/prompts/parser/test_random_generator.py
+++ b/tests/prompts/parser/test_random_generator.py
@@ -120,25 +120,33 @@ class TestVariantCommand:
         assert len(prompts) == 1
         assert prompts[0] == "one"
         command1._random.choices.assert_called_with(
-            variant_literals, weights=[1, 1, 1], k=1
+            variant_literals,
+            weights=[1, 1, 1],
+            k=1,
         )
 
         prompts = list(command1.prompts())
         assert prompts[0] == "two,one"
         command1._random.choices.assert_called_with(
-            variant_literals, weights=[1, 1, 1], k=2
+            variant_literals,
+            weights=[1, 1, 1],
+            k=2,
         )
 
         prompts = list(command1.prompts())
         assert prompts[0] == "three"
         command1._random.choices.assert_called_with(
-            variant_literals, weights=[1, 1, 1], k=1
+            variant_literals,
+            weights=[1, 1, 1],
+            k=1,
         )
 
         prompts = list(command1.prompts())
         assert prompts[0] == "three,one"
         command1._random.choices.assert_called_with(
-            variant_literals, weights=[1, 1, 1], k=2
+            variant_literals,
+            weights=[1, 1, 1],
+            k=2,
         )
 
     def test_variant_with_bound_and_sep(self):
@@ -157,7 +165,9 @@ class TestVariantCommand:
         assert len(prompts) == 1
         assert prompts[0] == "two and one"
         command1._random.choices.assert_called_with(
-            variant_literals, weights=[1, 1, 1], k=2
+            variant_literals,
+            weights=[1, 1, 1],
+            k=2,
         )
 
     def test_two_variants(self):
@@ -196,7 +206,7 @@ class TestVariantCommand:
         command6 = LiteralCommand(" ")
         command7 = LiteralCommand("cool")
         sequence = RandomSequenceCommand(
-            [command1, command2, command3, command4, command5, command6, command7]
+            [command1, command2, command3, command4, command5, command6, command7],
         )
 
         command1._random.choices.side_effect = [
@@ -239,7 +249,7 @@ class TestWildcardsCommand:
         command2 = builder.get_literal_action("are")
         command3 = builder.get_literal_action("cool")
         sequence = builder.get_sequence_action(
-            [command1, space, command2, space, command3]
+            [command1, space, command2, space, command3],
         )
 
         with mock.patch.object(
@@ -299,7 +309,7 @@ class TestRandomGenerator:
 
     def test_variants(self, generator: RandomGenerator):
         with mock.patch(
-            "dynamicprompts.parser.random_generator.random.choices"
+            "dynamicprompts.parser.random_generator.random.choices",
         ) as mock_random:
             random_choices = [
                 [to_seqlit("square")],
@@ -352,7 +362,7 @@ class TestRandomGenerator:
 
     def test_two_variants(self, generator: RandomGenerator):
         with mock.patch(
-            "dynamicprompts.parser.random_generator.random.choices"
+            "dynamicprompts.parser.random_generator.random.choices",
         ) as mock_random:
             mock_random.side_effect = [
                 [to_seqlit("green")],
@@ -394,7 +404,9 @@ class TestRandomGenerator:
 
     def test_missing_wildcard(self, generator: RandomGenerator):
         with mock.patch.object(
-            generator._wildcard_manager, "get_all_values", return_value=[]
+            generator._wildcard_manager,
+            "get_all_values",
+            return_value=[],
         ):
             prompts = generator.generate_prompts("A __missing__ wildcard", 1)
             assert len(prompts) == 1

--- a/tests/prompts/parser/test_random_generator.py
+++ b/tests/prompts/parser/test_random_generator.py
@@ -21,9 +21,11 @@ def to_seqlit(*args):
 def wildcard_manager():
     return mock.Mock()
 
+
 @pytest.fixture
 def builder(wildcard_manager):
     return RandomActionBuilder(wildcard_manager)
+
 
 @pytest.fixture
 def generator(wildcard_manager):
@@ -207,7 +209,6 @@ class TestVariantCommand:
             [to_seqlit("triangles")],
         ]
 
-
         assert sequence.get_prompt() == "red squares are cool"
         assert sequence.get_prompt() == "green triangles are cool"
 
@@ -219,7 +220,9 @@ class TestWildcardsCommand:
         command._random = mock.Mock()
 
         with mock.patch.object(
-            builder._wildcard_manager, "get_all_values", return_value=["red", "green", "blue"]
+            builder._wildcard_manager,
+            "get_all_values",
+            return_value=["red", "green", "blue"],
         ):
             command = cast(RandomWildcardCommand, command)
             command._random.choice.side_effect = ["green"]
@@ -235,10 +238,14 @@ class TestWildcardsCommand:
         space = builder.get_literal_action(" ")
         command2 = builder.get_literal_action("are")
         command3 = builder.get_literal_action("cool")
-        sequence = builder.get_sequence_action([command1, space, command2, space, command3])
+        sequence = builder.get_sequence_action(
+            [command1, space, command2, space, command3]
+        )
 
         with mock.patch.object(
-            builder._wildcard_manager, "get_all_values", return_value=["red", "green", "blue"]
+            builder._wildcard_manager,
+            "get_all_values",
+            return_value=["red", "green", "blue"],
         ):
 
             random_choices = ["green", "red"]
@@ -258,7 +265,9 @@ class TestWildcardsCommand:
         sequence = builder.get_sequence_action([command1, space, command3])
 
         with mock.patch.object(
-            builder._wildcard_manager, "get_all_values", return_value=["red", "green", "blue"]
+            builder._wildcard_manager,
+            "get_all_values",
+            return_value=["red", "green", "blue"],
         ):
 
             command1._random.choice.side_effect = ["red", "blue"]
@@ -358,7 +367,6 @@ class TestRandomGenerator:
 
     def test_weighted_variant(self, generator: RandomGenerator):
         generator._random = mock.Mock()
-
 
         generator._random.choices.return_value = [to_seqlit("green")]
         generator._random.randint.return_value = 1

--- a/tests/prompts/test_wildcardmanager.py
+++ b/tests/prompts/test_wildcardmanager.py
@@ -43,17 +43,19 @@ def test_collections(wildcard_manager: WildcardManager):
 
 def test_hierarchy(wildcard_manager: WildcardManager):
     assert wildcard_manager.get_wildcard_hierarchy() == (
-        ['__colors-cold__', '__colors-warm__'],  # Top level
+        ["__colors-cold__", "__colors-warm__"],  # Top level
         {  # child folders
-            'animals': (
-                ['__animals/mystical__'],
-                {'mammals': (
-                    ['__animals/mammals/canine__', '__animals/mammals/feline__'],
-                    {},
-                )},
+            "animals": (
+                ["__animals/mystical__"],
+                {
+                    "mammals": (
+                        ["__animals/mammals/canine__", "__animals/mammals/feline__"],
+                        {},
+                    )
+                },
             ),
-            'flavors': (
-                ['__flavors/sour__', '__flavors/sweet__'],
+            "flavors": (
+                ["__flavors/sour__", "__flavors/sweet__"],
                 {},
             ),
         },

--- a/tests/prompts/test_wildcardmanager.py
+++ b/tests/prompts/test_wildcardmanager.py
@@ -51,7 +51,7 @@ def test_hierarchy(wildcard_manager: WildcardManager):
                     "mammals": (
                         ["__animals/mammals/canine__", "__animals/mammals/feline__"],
                         {},
-                    )
+                    ),
                 },
             ),
             "flavors": (


### PR DESCRIPTION
This is pretty much just a mechanical PR for consistent code formatting. `black` is the "industry standard" formatting tool for Python.

I'm looking to follow this up with adding proper types wherever possible :)