### PR TITLE
Allow zero repetitions in sequence commands

### DIFF
--- a/src/dynamicprompts/parser/commands.py
+++ b/src/dynamicprompts/parser/commands.py
@@ -84,8 +84,8 @@ class VariantCommand(Command):
     def __init__(self, variants, min_bound=1, max_bound=1, sep=","):
         super().__init__(variants)
 
-        min_bound, max_bound = min(min_bound, max_bound), max(min_bound, max_bound)
-        self.min_bound = max(1, min_bound)
+        min_bound, max_bound = sorted((min_bound, max_bound))
+        self.min_bound = max(0, min_bound)
         self.max_bound = max_bound
         self.sep = sep
         self._weights = self._get_weights(variants)

--- a/tests/prompts/generators/test_combinatorial.py
+++ b/tests/prompts/generators/test_combinatorial.py
@@ -67,7 +67,6 @@ class TestCombinatorialGenerator:
         assert prompts[4] == "C|A"
         assert prompts[5] == "C|B"
 
-
     def test_all_generations(self, wildcard_manager):
         prompt = "I love __food__ and __drink__"
 

--- a/tests/prompts/parser/test_commands.py
+++ b/tests/prompts/parser/test_commands.py
@@ -98,7 +98,7 @@ class TestVariant:
             min_bound=-1,
             max_bound=10,
         )
-        assert variant_command.min_bound == 1
+        assert variant_command.min_bound == 0  # check that negative values are clamped
 
         variant_command = VariantCommand(
             gen_variant(literals),

--- a/tests/prompts/parser/test_parser.py
+++ b/tests/prompts/parser/test_parser.py
@@ -316,6 +316,17 @@ class TestParser:
 
         sequence = parser.parse("{2$$  $$cat|dog|bird}")
 
+    def test_range_sd_issue_223(self, parser: Parser):
+        # > {0-1$$a|b|c|d} would return nothing or one item. 0-1 could also be 0-3 etc.
+        # > Since 2.52, if the random number picker lands on 0, instead of returning an empty set,
+        # > the parser just stops and kicks out whatever it has, which results in a broken prompt.
+        # https://github.com/adieyal/sd-dynamic-prompts/issues/223
+        sequence = parser.parse(r"{0-1$$a|b|c|d}")
+        var = sequence[0]
+        assert isinstance(var, VariantCommand)
+        assert var.min_bound == 0
+        assert var.max_bound == 1
+
     def test_comments(self, parser: Parser):
 
         prompt = """

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from dynamicprompts.parser.combinatorial_generator import CombinatorialGenerator
+from dynamicprompts.parser.random_generator import RandomGenerator
+from dynamicprompts.wildcardmanager import WildcardManager
+
+
+@dataclasses.dataclass(frozen=True)
+class SmokeTestCase:
+    input: str
+    must_generate: bool = True
+    expected_combinatorial_count: int | None = None
+
+
+test_cases = [
+    SmokeTestCase(
+        r"foo {0-1$$a|b|c|d}",
+        must_generate=False,
+        expected_combinatorial_count=5,
+    ),
+    SmokeTestCase(
+        r"foo {a|b|c|d}",
+        must_generate=False,
+        expected_combinatorial_count=4,
+    ),
+]
+
+gen_class = [
+    CombinatorialGenerator,
+    RandomGenerator,
+]
+
+
+@pytest.mark.parametrize("gen", gen_class)
+@pytest.mark.parametrize("case", test_cases)
+def test_generator(gen, case: SmokeTestCase, wildcard_manager: WildcardManager):
+    generator = gen(wildcard_manager=wildcard_manager)
+    gen_count = 0
+    for result in generator.generate_prompts(case.input):
+        assert result
+        gen_count += 1
+    if case.must_generate:
+        assert gen_count
+    if case.expected_combinatorial_count is not None:
+        if gen is CombinatorialGenerator:
+            assert gen_count == case.expected_combinatorial_count


### PR DESCRIPTION
Fixes https://github.com/adieyal/sd-dynamic-prompts/issues/223 (probably)
I think this had regressed in c4e97255e00f351422614130ba358ad8a6083974