### PR TITLE
Removed the restriction on certain characters in literals

### DIFF
--- a/src/dynamicprompts/parser/parse.py
+++ b/src/dynamicprompts/parser/parse.py
@@ -77,10 +77,17 @@ def _configure_wildcard() -> pp.ParserElement:
 
 
 def _configure_literal_sequence(is_variant_literal: bool = False) -> pp.ParserElement:
+    # Characters that are not allowed in a literal
+    # - { denotes the start of a variant
+    # - # denotes the start of a comment
+    non_literal_chars = r"{#"
+
     if is_variant_literal:
-        non_literal_chars = r"{}|$#"
-    else:
-        non_literal_chars = r"{}$#"
+        # Inside a variant the following characters are also not allowed
+        # - } denotes the end of a variant
+        # - | denotes the end of a variant option
+        # - $ denotes the end of a bound expression
+        non_literal_chars += r"}|$"
 
     literal = pp.Regex(rf"((?!{double_underscore})[^{non_literal_chars}])+")(
         "literal",

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -23,6 +23,8 @@ class TestParser:
             "Test [low emphasis:0.4]",  # square brackets with weight
             "Test (high emphasis)",  # round brackets
             "Test (high emphasis:0.4)",  # round brackets with weight
+            "Unmatched } bracket",
+            "$$ are fine outside of variants",
         ],
     )
     def test_literal_characters(self, input: str):
@@ -95,10 +97,6 @@ class TestParser:
     def test_variant_breaks_without_closing_bracket(self):
         with pytest.raises(ParseException):
             parse("{cat|dog")
-
-    def test_variant_breaks_without_opening_bracket(self):
-        with pytest.raises(ParseException):
-            parse("cat|dog}")
 
     def test_variant_with_wildcard(self):
         variant = parse("{__test/colours__|washington}")


### PR DESCRIPTION
An unmatched } is now allowed, but not inside a variant 
A $ is now allowed but not in a variant

Fixes #22 