### PR TITLE
fix broken symlink support

### DIFF
--- a/src/dynamicprompts/wildcardmanager.py
+++ b/src/dynamicprompts/wildcardmanager.py
@@ -74,7 +74,7 @@ class WildcardManager:
         return [
             WildcardFile(path)
             for path in self._path.rglob(f"{wildcard}.{constants.WILDCARD_SUFFIX}")
-            if _is_relative_to(path.resolve(), self._path)
+            if _is_relative_to(path.absolute(), self._path)
         ]
 
     def wildcard_to_path(self, wildcard: str) -> Path:


### PR DESCRIPTION
See explanation of similar PR @ https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/7535

Same concept as there applies here, wildcards under a symlink show ui the WebUI's "Wildcards Manager" tab but can't actually be used in prompts because this check was using the wrong method. This one change seems sufficient to get it working in a quick test.