### PR TITLE
Add test for symlink support

### DIFF
--- a/src/dynamicprompts/wildcardfile.py
+++ b/src/dynamicprompts/wildcardfile.py
@@ -7,10 +7,20 @@ from dynamicprompts.utils import is_empty_line
 
 
 class WildcardFile:
-    def __init__(self, path: Path, encoding: str = DEFAULT_ENCODING) -> None:
+    def __init__(
+        self,
+        path: Path,
+        encoding: str = DEFAULT_ENCODING,
+        name: str | None = None,
+    ) -> None:
         self._path = path
         self._encoding = encoding
+        self._name = name or path.name
         self._cache: set[str] | None = None
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     def __str__(self) -> str:
         return f"<WildcardFile: {self._path}>"

--- a/src/dynamicprompts/wildcardmanager.py
+++ b/src/dynamicprompts/wildcardmanager.py
@@ -72,7 +72,7 @@ class WildcardManager:
             return []
 
         return [
-            WildcardFile(path)
+            WildcardFile(path, name=self.path_to_wildcard_without_separators(path))
             for path in self._path.rglob(f"{wildcard}.{constants.WILDCARD_SUFFIX}")
             if _is_relative_to(path.absolute(), self._path)
         ]
@@ -82,9 +82,12 @@ class WildcardManager:
             f".{constants.WILDCARD_SUFFIX}",
         )
 
-    def path_to_wildcard(self, path: Path) -> str:
+    def path_to_wildcard_without_separators(self, path: Path) -> str:
         rel_path = path.relative_to(self._path)
-        return f"__{str(rel_path.with_suffix('')).replace(os.sep, '/')}__"
+        return str(rel_path.with_suffix("")).replace(os.sep, "/")
+
+    def path_to_wildcard(self, path: Path) -> str:
+        return f"__{self.path_to_wildcard_without_separators(path)}__"
 
     def get_wildcards(self) -> list[str]:
         files = self.get_files(relative=True)

--- a/tests/test_wildcardmanager.py
+++ b/tests/test_wildcardmanager.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from dynamicprompts.wildcardmanager import WildcardManager, _clean_wildcard
 
@@ -81,3 +83,66 @@ def test_clean_wildcard():
 
     with pytest.raises(ValueError):
         _clean_wildcard("foo/../bar")
+
+
+def test_wildcard_symlinks(tmp_path: Path):
+    internet_animals = {"doggo", "catto", "otto"}
+    cool_animals = {"cool bear", "cool penguin"}
+    wild_things = {"plants", "forest", "flowers", "sunshine"}
+
+    # Prepare a file outside the wildcard directory
+    # that we'll have a symlink point to.
+    # We will be able to read this file via the symlink.
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    secret_file = outside_dir / "wilderness.txt"
+    secret_file.write_text("\n".join(wild_things))
+
+    # Prepare the wildcard directory with real files...
+    wildcards_dir = tmp_path / "wildcards"
+    animals_dir = wildcards_dir / "animals"
+    animals_dir.mkdir(parents=True)
+    internet_animals_file = animals_dir / "internet.txt"
+    internet_animals_file.write_text("\n".join(internet_animals))
+    cool_animals_file = animals_dir / "cool.txt"
+    cool_animals_file.write_text("\n".join(cool_animals))
+
+    # Prepare symlinks.
+    friendos_file = wildcards_dir / "friendos.txt"
+    friendos_file.symlink_to(internet_animals_file)
+    polar_file = wildcards_dir / "wow_polar.txt"
+    polar_file.symlink_to(cool_animals_file.relative_to(polar_file.parent))
+    wild_file = wildcards_dir / "wild.txt"
+    wild_file.symlink_to(secret_file)
+
+    wcm = WildcardManager(wildcards_dir)
+    assert {w.name for w in wcm.match_files("*")} == {
+        "animals/cool",
+        "animals/internet",
+        "friendos",
+        "wild",
+        "wow_polar",
+    }
+
+    # Check that regular and symlinked files are available.
+    assert (
+        set(wcm.get_all_values("animals/internet"))
+        == set(wcm.get_all_values("friendos"))
+        == internet_animals
+    )
+
+    # Wilderness available via symlink?
+    assert set(wcm.get_all_values("wild")) == wild_things
+    # ... No directory traversal though!
+    assert not wcm.get_all_values("../outside/wilderness")
+
+    # Now, let's get extra wild and symlink an entire directory...
+    wildly_dir = wildcards_dir / "wildly"
+    wildly_dir.symlink_to(outside_dir)
+    # ... and write some more there!
+    wilder_file = wildly_dir / "wilder.txt"
+    wilder_file.write_text("whoa!!!")
+    assert set(wcm.get_all_values("wildly/*")) == {
+        *wild_things,
+        "whoa!!!",
+    }


### PR DESCRIPTION
This adds a proper test for symlink support.

Symlinks are able to point outside the wildcard root directory; this assumes no one can plant a malicious symlink in the user's wildcard directory.