### PR TITLE
Bug/more hardcoded wildcard wrap

### DIFF
--- a/src/dynamicprompts/constants.py
+++ b/src/dynamicprompts/constants.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-import re
-
 DEFAULT_ENCODING = "utf-8"
 DEFAULT_COMBO_JOINER = ","
 MAX_IMAGES = 1000
 WILDCARD_SUFFIX = "txt"
-WILDCARD_RE = re.compile(r"__(.*?)__")
-COMBINATIONS_RE = re.compile(r"\{([^{}]*)}")

--- a/src/dynamicprompts/jinja_extensions.py
+++ b/src/dynamicprompts/jinja_extensions.py
@@ -10,9 +10,6 @@ from jinja2.ext import Extension
 from jinja2.nodes import CallBlock
 from jinja2.parser import Parser
 
-from dynamicprompts.constants import COMBINATIONS_RE, WILDCARD_RE
-from dynamicprompts.wildcardmanager import WildcardManager
-
 logger = logging.getLogger(__name__)
 
 
@@ -42,19 +39,10 @@ def permutation(
 
 @pass_environment
 def wildcard(environment: Environment, wildcard_name: str) -> list[str]:
-    wm = cast(WildcardManager, environment.globals["wildcard_manager"])
-    values = []
+    generators = environment.globals["generators"]
+    generator = generators["combinatorial"]  # type: ignore
 
-    for value in wm.get_all_values(wildcard_name):
-        if WILDCARD_RE.fullmatch(value):
-            values.extend(wildcard(environment, value))
-        elif COMBINATIONS_RE.fullmatch(value):
-            val = COMBINATIONS_RE.findall(value)[0]
-            options = val.split("|")
-            values.append(choice(options))
-        else:
-            values.append(value)
-    return values
+    return list(generator.generate(wildcard_name))
 
 
 class PromptExtension(Extension):

--- a/src/dynamicprompts/sampler_routers/concrete_sampler_router.py
+++ b/src/dynamicprompts/sampler_routers/concrete_sampler_router.py
@@ -31,6 +31,7 @@ class ConcreteSamplerRouter(SamplerRouter):
     ):
         self._wildcard_manager = wildcard_manager
         self._ignore_whitespace = ignore_whitespace
+        self._parser_config = parser_config
 
         if samplers is None:
             samplers = self._build_default_samplers(
@@ -104,6 +105,7 @@ class ConcreteSamplerRouter(SamplerRouter):
         if isinstance(prompt, str):
             command = parse(
                 prompt,
+                parser_config=self._parser_config,
                 default_sampling_method=self._default_sampling_method,
             )
         elif isinstance(prompt, Command):

--- a/src/dynamicprompts/utils.py
+++ b/src/dynamicprompts/utils.py
@@ -10,6 +10,14 @@ from dynamicprompts.types import StringGen
 T = TypeVar("T")
 
 
+def removeprefix(s: str, prefix: str) -> str:
+    return s[len(prefix) :] if s.startswith(prefix) else s
+
+
+def removesuffix(s: str, suffix: str) -> str:
+    return s[: -len(suffix)] if s.endswith(suffix) else s
+
+
 def squash_whitespace(s: str) -> str:
     return " ".join(s.split())
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,16 @@
-from dynamicprompts.utils import dedupe
+from dynamicprompts.utils import dedupe, removeprefix, removesuffix
 
 
 def test_dedupe():
     arr = ["a", "b", "a", "c", "b", "d"]
     assert dedupe(arr) == ("a", "b", "c", "d")
+
+
+def test_remove_prefix():
+    assert removeprefix("foobar", "foo") == "bar"
+    assert removeprefix("foobar", "bar") == "foobar"
+
+
+def test_remove_suffix():
+    assert removesuffix("foobar", "bar") == "foo"
+    assert removesuffix("foobar", "foo") == "foobar"

--- a/tests/test_wildcardmanager.py
+++ b/tests/test_wildcardmanager.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from functools import partial
 from pathlib import Path
 
 import pytest
@@ -90,15 +93,25 @@ def test_directory_traversal(wildcard_manager: WildcardManager):
     assert not wildcard_manager.get_all_values("..\\cant_touch_this")
 
 
-def test_clean_wildcard():
+def test_clean_wildcard(wildcard_manager: WildcardManager):
+    clean = partial(_clean_wildcard, wildcard_wrap=wildcard_manager.wildcard_wrap)
     with pytest.raises(ValueError):
-        _clean_wildcard("/foo")
+        clean("/foo")
 
     with pytest.raises(ValueError):
-        _clean_wildcard("\\foo")
+        clean("\\foo")
 
     with pytest.raises(ValueError):
-        _clean_wildcard("foo/../bar")
+        clean("foo/../bar")
+
+    ww = wildcard_manager.wildcard_wrap
+    assert clean(f"{ww}foo{ww}", wildcard_wrap=ww) == "foo"
+
+
+def test_to_wildcard(wildcard_manager: WildcardManager):
+    ww = wildcard_manager.wildcard_wrap
+
+    assert wildcard_manager.to_wildcard("foo") == f"{ww}foo{ww}"
 
 
 def test_path_to_wildcard_without_separators(wildcard_manager: WildcardManager):


### PR DESCRIPTION
I've fixed a few more of the hardcoded wildcard_wrap. This ended up requiring that the JinjaGenerator be updated to use the CombinatorialPromptGenerator internally for parsing rather than separately maintaining the regex that used to live in constants.py.

Taking advantage of this, a PR will follow that adds two new jinja extensions for parsing arbitrary prompts using the RandomPromptGenerator and CombinatorialPromptGenerator. MagicPrompt and friends will may also be added.

@akx I've been hesitant to make these changes while you're working #40  since I know that merging may end up being messy but I thought it better to write it now and clean it up later once you're done.