### PR TITLE
Don't require manual wildcard wrapping in Jinja

### DIFF
--- a/src/dynamicprompts/jinja_extensions.py
+++ b/src/dynamicprompts/jinja_extensions.py
@@ -39,10 +39,13 @@ def permutation(
 
 @pass_environment
 def wildcard(environment: Environment, wildcard_name: str) -> list[str]:
-    generators = environment.globals["generators"]
-    generator = generators["combinatorial"]  # type: ignore
+    from dynamicprompts.generators import CombinatorialPromptGenerator
+    from dynamicprompts.wildcardmanager import WildcardManager
 
-    return list(generator.generate(wildcard_name))
+    wm: WildcardManager = environment.globals["wildcard_manager"]  # type: ignore
+    generator: CombinatorialPromptGenerator = environment.globals["generators"]["combinatorial"]  # type: ignore
+
+    return list(generator.generate(wm.to_wildcard(wildcard_name)))
 
 
 class PromptExtension(Extension):

--- a/src/dynamicprompts/wildcardmanager.py
+++ b/src/dynamicprompts/wildcardmanager.py
@@ -117,8 +117,15 @@ class WildcardManager:
         return sorted(set().union(*[f.get_wildcards() for f in files]))
 
     def to_wildcard(self, name: str) -> str:
+        """
+        Wrap `name` in the wildcard wrap string if it is not already wrapped.
+        """
         ww = self._wildcard_wrap
-        return f"{ww}{name}{ww}"
+        if not name.startswith(ww):
+            name = f"{ww}{name}"
+        if not name.endswith(ww):
+            name = f"{name}{ww}"
+        return name
 
     # TODO: the return type is actually a recursive type (replace that Any)
     def get_wildcard_hierarchy(

--- a/tests/generators/test_jinja.py
+++ b/tests/generators/test_jinja.py
@@ -72,12 +72,16 @@ class TestJinjaGenerator:
             "My favourite colour is green",
         ]
 
+    @pytest.mark.parametrize("wrapped", [False, True])
     def test_wildcards(
         self,
         generator: JinjaGenerator,
         wildcard_manager: WildcardManager,
+        wrapped: bool,
     ):
-        wildcard = wildcard_manager.to_wildcard("colors-cold")
+        wildcard = "colors-cold"
+        if wrapped:
+            wildcard = wildcard_manager.to_wildcard(wildcard)
         template = f"""
         {{% for colour in wildcard("{wildcard}") %}}
             {{% prompt %}}My favourite colour is {{{{ colour }}}}{{% endprompt %}}

--- a/tests/test_wildcardmanager.py
+++ b/tests/test_wildcardmanager.py
@@ -110,8 +110,8 @@ def test_clean_wildcard(wildcard_manager: WildcardManager):
 
 def test_to_wildcard(wildcard_manager: WildcardManager):
     ww = wildcard_manager.wildcard_wrap
-
     assert wildcard_manager.to_wildcard("foo") == f"{ww}foo{ww}"
+    assert wildcard_manager.to_wildcard(f"{ww}foo{ww}") == f"{ww}foo{ww}"
 
 
 def test_path_to_wildcard_without_separators(wildcard_manager: WildcardManager):


### PR DESCRIPTION
IOW, `{{ wildcard("colors") }}` is equivalent to `{{ wildcard("__colors__") }}`; as a side-effect, `wm.to_wildcard('__colors__')` will return `__colors__`, not `____colors____`.