### PR TITLE
Down with random patching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ ignore = [
 ]
 unfixable = [
     "T2",  # don't automatically remove prints
+    "F841",  # don't remove seemingly unused locals
 ]
 
 [tool.ruff.flake8-tidy-imports]

--- a/src/dynamicprompts/samplers/random.py
+++ b/src/dynamicprompts/samplers/random.py
@@ -56,6 +56,17 @@ class RandomSampler(Sampler):
             rand=self._random,
         )
 
+    def _get_variant_num_choices(self, variant_command: VariantCommand) -> int:
+        # Wraps randint for ease of testing
+        return self._random.randint(
+            variant_command.min_bound,
+            variant_command.max_bound,
+        )
+
+    def _get_wildcard_choice(self, values: list[str]) -> str:
+        # Wraps choice for ease of testing
+        return self._random.choice(values)
+
     def _get_random_variant(
         self,
         variant_command: VariantCommand,
@@ -70,10 +81,7 @@ class RandomSampler(Sampler):
             )
         else:
             while True:
-                num_choices = self._random.randint(
-                    variant_command.min_bound,
-                    variant_command.max_bound,
-                )
+                num_choices = self._get_variant_num_choices(variant_command)
 
                 selected_commands = self._get_variant_choices(
                     variant_command.values,
@@ -103,7 +111,7 @@ class RandomSampler(Sampler):
             if len(values) == 0:
                 yield f"__{command.wildcard}__"
             else:
-                value = self._random.choice(values)
+                value = self._get_wildcard_choice(values)
                 yield from self._sampler_router.sample_prompts(value, 1)
 
     def _propagate_sampling_method(self, commands: Iterable[Command]) -> None:

--- a/tests/samplers/test_common.py
+++ b/tests/samplers/test_common.py
@@ -569,20 +569,20 @@ class TestWildcardsCommand:
             (
                 lazy_fixture("cyclical_sampler_router"),
                 [
+                    "blue",
                     "red",
                     "green",
-                    "blue",
-                    "pink",
-                    "green",
-                    "blue",
                     "yellow",
+                    "blue",
+                    "red",
                     "green",
+                    "yellow",
                     "blue",
                 ],
             ),
             (
                 lazy_fixture("combinatorial_sampler_router"),
-                ["red", "pink", "yellow", "green", "blue"],
+                ["blue", "green", "red", "yellow"],
             ),
         ],
     )
@@ -591,20 +591,7 @@ class TestWildcardsCommand:
         sampler_router: ConcreteSamplerRouter,
         expected: list[str],
     ):
-        test_colours = [
-            ["__other_colours__", "green", "blue"],
-            ["red", "pink", "yellow"],
-        ]
-
-        with patch.object(
-            sampler_router._wildcard_manager,
-            "get_all_values",
-            side_effect=test_colours,
-        ):
-            wildcard_command = WildcardCommand("colours")
-            sequence = SequenceCommand([wildcard_command])
-
-            gen = sampler_router.generator_from_command(sequence)
-
-            prompts = [next(gen) for _ in range(len(expected))]
-            assert prompts == expected
+        wildcard_command = WildcardCommand("referencing-colors")
+        sequence = SequenceCommand([wildcard_command])
+        gen = sampler_router.generator_from_command(sequence)
+        assert list(islice(gen, len(expected))) == expected

--- a/tests/samplers/utils.py
+++ b/tests/samplers/utils.py
@@ -23,3 +23,35 @@ def patch_random_sampler_variant_choices(random_choices: list[list[Command]]):
         "_get_variant_choices",
         side_effect=random_choices,
     )
+
+
+def patch_random_sampler_variant_num_choices(num_choices: list[int]):
+    """
+    Return a mock.patch.object context manager that RandomSampler to return
+    the given sequence of num_choices for variant commands.
+    """
+    # Guard against misuse of this utility
+    assert isinstance(num_choices, list)
+    assert all(isinstance(num, int) for num in num_choices)
+    # Good to go
+    return patch.object(
+        RandomSampler,
+        "_get_variant_num_choices",
+        side_effect=num_choices,
+    )
+
+
+def patch_random_sampler_wildcard_choice(choices: list[str]):
+    """
+    Return a mock.patch.object context manager that RandomSampler to return
+    the given sequence of wildcard choices.
+    """
+    # Guard against misuse of this utility
+    assert isinstance(choices, list)
+    assert all(isinstance(choice, str) for choice in choices)
+    # Good to go
+    return patch.object(
+        RandomSampler,
+        "_get_wildcard_choice",
+        side_effect=choices,
+    )

--- a/tests/test_data/wildcards/referencing-colors.txt
+++ b/tests/test_data/wildcards/referencing-colors.txt
@@ -1,0 +1,2 @@
+__colors-warm__
+__colors-cold__

--- a/tests/test_wildcardmanager.py
+++ b/tests/test_wildcardmanager.py
@@ -62,6 +62,7 @@ def test_hierarchy(wildcard_manager: WildcardManager):
         [
             to_wildcard("colors-cold"),
             to_wildcard("colors-warm"),
+            to_wildcard("referencing-colors"),
             to_wildcard("variant"),
         ],  # Top level
         {  # child folders


### PR DESCRIPTION
Extracted from #40, follows up on #46 and #47.

Gets rid of whatever patching of `random` remained in favor of higher-level things, and also makes a wildcard test use actual wildcards.