### PR TITLE
Enable codecov in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
             pyproject.toml
       - name: Install dependencies
         run: python -m pip install pytest-lazy-fixture pytest-cov -e .[attentiongrabber,magicprompt]
-      - run: pytest --cov --cov-report=term-missing .
+      - run: pytest --cov --cov-report=term-missing --cov-report=xml .
         env:
           PYPARSINGENABLEALLWARNINGS: 1
+      - uses: codecov/codecov-action@v3


### PR DESCRIPTION
This enables the [Codecov.io](https://about.codecov.io/) GitHub action to track and report code coverage in PRs and over time.

100% coverage isn't required, but it tends to be good to see if newly added lines aren't exercised by tests.

The repo may need to be separately activated on Codecov if nothing happens.