### PR TITLE
add combirandom (weighted random without replacement) variant picker

### DIFF
--- a/src/dynamicprompts/generators/__init__.py
+++ b/src/dynamicprompts/generators/__init__.py
@@ -7,6 +7,7 @@ from dynamicprompts.generators.feelinglucky import FeelingLuckyGenerator
 from dynamicprompts.generators.jinjagenerator import JinjaGenerator
 from dynamicprompts.generators.promptgenerator import PromptGenerator
 from dynamicprompts.generators.randomprompt import RandomPromptGenerator
+from dynamicprompts.generators.combirandomgenerator import CombiRandomPromptGenerator
 
 __all__ = [
     "BatchedCombinatorialPromptGenerator",
@@ -16,4 +17,5 @@ __all__ = [
     "JinjaGenerator",
     "PromptGenerator",
     "RandomPromptGenerator",
+    "CombiRandomPromptGenerator",
 ]

--- a/src/dynamicprompts/generators/combirandomgenerator.py
+++ b/src/dynamicprompts/generators/combirandomgenerator.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+from random import Random
+
+from dynamicprompts.generators.promptgenerator import PromptGenerator
+from dynamicprompts.parser.config import ParserConfig, default_parser_config
+from dynamicprompts.samplers.random import DEFAULT_RANDOM
+from dynamicprompts.samplers import CombiRandomSampler
+from dynamicprompts.wildcardmanager import WildcardManager
+
+logger = logging.getLogger(__name__)
+
+
+class CombiRandomPromptGenerator(PromptGenerator):
+    def __init__(
+        self,
+        wildcard_manager: WildcardManager,
+        seed: int | None = None,
+        unlink_seed_from_prompt: bool = False,
+        ignore_whitespace: bool = False,
+        parser_config: ParserConfig = default_parser_config,
+    ) -> None:
+        self._wildcard_manager = wildcard_manager
+        self._unlink_seed_from_prompt = unlink_seed_from_prompt
+
+        if self._unlink_seed_from_prompt:
+            self._random = DEFAULT_RANDOM
+        else:
+            self._random = Random()
+            if seed is not None:
+                self._random.seed(seed)
+
+        self._sampler = CombiRandomSampler(
+            wildcard_manager=wildcard_manager,
+            rand=self._random,
+            ignore_whitespace=ignore_whitespace,
+            parser_config=parser_config,
+        )
+
+    def generate(
+        self,
+        template: str | None,
+        num_images: int = 1,
+    ) -> list[str]:
+        if template is None or len(template) == 0:
+            return [""]
+        return list(self._sampler.generate_prompts(template, num_images))

--- a/src/dynamicprompts/samplers/__init__.py
+++ b/src/dynamicprompts/samplers/__init__.py
@@ -1,9 +1,11 @@
 from dynamicprompts.samplers.base import Sampler
 from dynamicprompts.samplers.combinatorial import CombinatorialSampler
 from dynamicprompts.samplers.random import RandomSampler
+from dynamicprompts.samplers.combirandom import CombiRandomSampler
 
 __all__ = [
     "CombinatorialSampler",
     "RandomSampler",
     "Sampler",
+    "CombiRandomSampler"
 ]

--- a/src/dynamicprompts/samplers/combirandom.py
+++ b/src/dynamicprompts/samplers/combirandom.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import logging
+import typing
+from random import Random
+
+from dynamicprompts.commands import (
+    Command,
+    LiteralCommand,
+    SequenceCommand,
+    VariantCommand,
+    WildcardCommand,
+)
+from dynamicprompts.parser.config import ParserConfig, default_parser_config
+from dynamicprompts.samplers.base import Sampler
+from dynamicprompts.wildcardmanager import WildcardManager
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RANDOM = Random()
+
+def weighted_sample_without_replacement(population, weights, random, k = 1):
+    weights = list(weights)
+    positions = range(len(population))
+    indices = []
+    while True:
+        needed = k - len(indices)
+        if not needed:
+            break
+        for i in random.choices(positions, weights, k=needed):
+            if weights[i]:
+                weights[i] = 0.0
+                indices.append(i)
+    return [population[i] for i in indices]
+
+def _get_combirandom_variant(
+    generator: Sampler,
+    variant_command: VariantCommand,
+    random: Random,
+) -> typing.Generator[str, None, None]:
+    if len(variant_command.values) == 0:
+        return
+    elif len(variant_command.values) == 1:
+        yield from generator.generator_from_command(variant_command.values[0])
+    else:
+        while True:
+            num_choices = random.randint(
+                variant_command.min_bound,
+                variant_command.max_bound,
+            )
+            selected_commands = weighted_sample_without_replacement(
+                variant_command.values,
+                variant_command.weights,
+                random,
+                k=(num_choices % len(variant_command.values)),
+            )
+            if len(variant_command.values) < num_choices:
+                selected_commands.extend(variant_command.values * (num_choices // len(variant_command.values)))
+            sub_generators = [
+                generator.generator_from_command(c) for c in selected_commands
+            ]
+            yield variant_command.separator.join(
+                next(subgen) for subgen in sub_generators
+            )
+
+
+class CombiRandomSampler(Sampler):
+    def __init__(
+        self,
+        *,
+        wildcard_manager: WildcardManager,
+        ignore_whitespace: bool = False,
+        rand: Random = DEFAULT_RANDOM,
+        parser_config: ParserConfig = default_parser_config,
+    ):
+        super().__init__(
+            wildcard_manager=wildcard_manager,
+            ignore_whitespace=ignore_whitespace,
+            parser_config=parser_config,
+        )
+        self._random = rand
+
+    def generator_from_command(
+        self,
+        command: Command,
+    ) -> typing.Generator[str, None, None]:
+        if isinstance(command, LiteralCommand):
+            while True:
+                yield command.literal
+        elif isinstance(command, SequenceCommand):
+            sub_generators = [self.generator_from_command(c) for c in command.tokens]
+            while True:
+                yield command.separator.join(next(subgen) for subgen in sub_generators)
+        elif isinstance(command, VariantCommand):
+            yield from _get_combirandom_variant(self, command, self._random)
+        elif isinstance(command, WildcardCommand):
+            values = self._wildcard_manager.get_all_values(command.wildcard)
+            while True:
+                if len(values) == 0:
+                    logger.warning(f"No values found for wildcard {command.wildcard}")
+                    yield f"__{command.wildcard}__"
+                else:
+                    value = self._random.choice(values)
+                    # Parse and generate prompts from wildcard value
+                    yield from self.generate_prompts(value, 1)
+        else:
+            raise NotImplementedError(
+                f"{self.__class__.__qualname__}: Not implemented: {command}",
+            )


### PR DESCRIPTION
This is an improvised enhancement regarding issue https://github.com/adieyal/sd-dynamic-prompts/issues/166 ,

Current combination token($$) works with random.choice, which is combination with replacement(repetition), which is useful for many situation. However in some situation, user do not want to repeat prompt, especially when someone is using combination to choose and mix multiple lora(i.e., {2$$<lora:artistA:0.3>|<lora:artistB:0.3>|…}.), because repetition of single lora can negatively affect result, and that was my case.

This 'combirandom' prompt generator/sampler tackles the problem. some points to regard:

- since 'without replacement' actually modifies pool every time, it's uncanonical to have weights on them. it's okay when choose size is less or equal than pool size(this is almost every use cases), but it's hard to define behavior beyond that. In this implementation I just wanted to be robust about that regard. Details are in the code, just example {5$$2::a|b} result in 66% {a, a, b, a, b} and 33% {b, a, b, a, b}. (two sets of (a, b) are guaranteed).

This pull request is not meant to merged(I actually didn't know 0.7.1 is far behind) easily, rather this is proof of concept. 