### PR TITLE
Null wildcard manager is used by default

### DIFF
--- a/src/dynamicprompts/generators/combinatorial.py
+++ b/src/dynamicprompts/generators/combinatorial.py
@@ -16,10 +16,11 @@ logger = logging.getLogger(__name__)
 class CombinatorialPromptGenerator(PromptGenerator):
     def __init__(
         self,
-        wildcard_manager: WildcardManager,
+        wildcard_manager: WildcardManager | None = None,
         ignore_whitespace: bool = False,
         parser_config: ParserConfig = default_parser_config,
     ) -> None:
+        wildcard_manager = wildcard_manager or WildcardManager()
         self._context = SamplingContext(
             wildcard_manager=wildcard_manager,
             default_sampling_method=SamplingMethod.COMBINATORIAL,

--- a/src/dynamicprompts/generators/randomprompt.py
+++ b/src/dynamicprompts/generators/randomprompt.py
@@ -25,12 +25,13 @@ def _get_random(*, seed: int | None, unlink_seed_from_prompt: bool) -> Random:
 class RandomPromptGenerator(PromptGenerator):
     def __init__(
         self,
-        wildcard_manager: WildcardManager,
+        wildcard_manager: WildcardManager | None = None,
         seed: int | None = None,
         unlink_seed_from_prompt: bool = False,
         ignore_whitespace: bool = False,
         parser_config: ParserConfig = default_parser_config,
     ) -> None:
+        wildcard_manager = wildcard_manager or WildcardManager()
         self._context = SamplingContext(
             wildcard_manager=wildcard_manager,
             default_sampling_method=SamplingMethod.RANDOM,

--- a/tests/generators/test_combinatorial.py
+++ b/tests/generators/test_combinatorial.py
@@ -91,3 +91,7 @@ class TestCombinatorialGenerator:
         prompts = generator.generate(prompt)
 
         assert len(list(prompts)) == 9
+
+    def test_without_wildcard_manager(self):
+        generator = CombinatorialPromptGenerator()
+        assert generator._context.wildcard_manager.path is None

--- a/tests/generators/test_random.py
+++ b/tests/generators/test_random.py
@@ -1,0 +1,33 @@
+import pytest
+from dynamicprompts.generators.randomprompt import RandomPromptGenerator
+from dynamicprompts.wildcardmanager import WildcardManager
+
+from tests.samplers.utils import patch_random_sampler_wildcard_choice
+
+
+@pytest.fixture
+def generator(wildcard_manager: WildcardManager) -> RandomPromptGenerator:
+    return RandomPromptGenerator(wildcard_manager)
+
+
+class TestRandomGenerator:
+    def test_literal_template(self, generator):
+        prompt = "I love bread"
+
+        prompts = list(generator.generate(prompt, 10))
+
+        assert len(prompts) == 10
+        assert prompts[0] == prompt
+
+    def test_generate_with_wildcard(self, generator):
+        prompt = "I saw a __mammals/*__"
+        animals = ["dog", "dog", "wolf", "tiger"]
+
+        with patch_random_sampler_wildcard_choice(animals):
+            prompts = list(generator.generate(prompt, 4))
+
+        assert prompts == [f"I saw a {animal}" for animal in animals]
+
+    def test_without_wildcard_manager(self):
+        generator = RandomPromptGenerator()
+        assert generator._context.wildcard_manager.path is None


### PR DESCRIPTION
If a wildcard manager is not passed into the Combinatorial and RandomPrompt generators, a null WildcardManager is used