### PR TITLE
Don't allow attention grabber to mess with A1111 special syntax

### DIFF
--- a/src/dynamicprompts/constants.py
+++ b/src/dynamicprompts/constants.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from random import Random
 
 DEFAULT_ENCODING = "utf-8"
@@ -7,3 +8,6 @@ DEFAULT_COMBO_JOINER = ","
 MAX_IMAGES = 1000
 WILDCARD_SUFFIX = "txt"
 DEFAULT_RANDOM = Random()
+
+# A1111 special syntax (LoRA, hypernet, etc.)
+A1111_SPECIAL_SYNTAX_RE = re.compile(r"\s*<[^>]+>")

--- a/src/dynamicprompts/generators/attentiongenerator.py
+++ b/src/dynamicprompts/generators/attentiongenerator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import random
+from functools import lru_cache
 
 from dynamicprompts.generators.dummygenerator import DummyGenerator
 from dynamicprompts.generators.promptgenerator import PromptGenerator
@@ -36,7 +37,7 @@ class AttentionGenerator(PromptGenerator):
 
             download(MODEL_NAME)
 
-        self._nlp = spacy.load(MODEL_NAME)
+        self._nlp = lru_cache(maxsize=64)(spacy.load(MODEL_NAME))
 
         if generator is None:
             self._prompt_generator = DummyGenerator()

--- a/src/dynamicprompts/generators/attentiongenerator.py
+++ b/src/dynamicprompts/generators/attentiongenerator.py
@@ -5,6 +5,7 @@ import random
 
 from dynamicprompts.generators.dummygenerator import DummyGenerator
 from dynamicprompts.generators.promptgenerator import PromptGenerator
+from dynamicprompts.utils import append_chunks, remove_a1111_special_syntax_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,9 @@ class AttentionGenerator(PromptGenerator):
         self._min_attention, self._max_attention = m, M
 
     def _add_emphasis(self, prompt: str) -> str:
+        # Grab the special chunks first, so we don't accidentally add emphasis to them
+        prompt, special_chunks = remove_a1111_special_syntax_chunks(prompt)
+
         doc = self._nlp(prompt)
         keywords = list(doc.noun_chunks)
         if len(keywords) == 0:
@@ -55,7 +59,8 @@ class AttentionGenerator(PromptGenerator):
         attention = round(random.uniform(self._min_attention, self._max_attention), 2)
         prompt = prompt.replace(str(keyword), f"({keyword}:{attention})")
 
-        return prompt
+        # Add the special chunks back in
+        return append_chunks(prompt, special_chunks)
 
     def generate(self, *args, **kwargs) -> list[str]:
         prompts = self._prompt_generator.generate(*args, **kwargs)

--- a/src/dynamicprompts/utils.py
+++ b/src/dynamicprompts/utils.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import random
+import re
 from collections import OrderedDict
 from itertools import cycle
 from typing import Iterable, TypeVar
 
+from dynamicprompts.constants import A1111_SPECIAL_SYNTAX_RE
 from dynamicprompts.types import StringGen
 
 T = TypeVar("T")
@@ -91,3 +93,25 @@ def choose_without_replacement(
             weights.remove(weights[values.index(chosen)])
             values.remove(chosen)
         return chosen_values
+
+
+def remove_a1111_special_syntax_chunks(s: str) -> tuple[str, list[str]]:
+    """
+    Remove A1111 special syntax chunks from a string and return the string and the chunks.
+    """
+    chunks: list[str] = []
+
+    def put_chunk(m):
+        chunks.append(m.group(0))
+        return ""
+
+    return re.sub(A1111_SPECIAL_SYNTAX_RE, put_chunk, s), chunks
+
+
+def append_chunks(s: str, chunks: list[str]) -> str:
+    """
+    Append (A1111 special syntax) chunks to a string.
+    """
+    if not chunks:
+        return s
+    return f"{s}{''.join(chunks)}"

--- a/tests/generators/test_attentiongenerator.py
+++ b/tests/generators/test_attentiongenerator.py
@@ -6,6 +6,14 @@ from dynamicprompts.generators.attentiongenerator import AttentionGenerator
 def test_default_generator():
     pytest.importorskip("spacy")
     generator = AttentionGenerator()
-    for prompt in generator.generate("purple cat singing opera, artistic, painting", 5):
+    for prompt in generator.generate(
+        "purple cat singing opera, artistic, painting "
+        "<lora:loraname:0.7> <hypernet:v18000Steps:1>",
+        5,
+    ):
+        # These must remain unchanged
+        assert "<lora:loraname:0.7>" in prompt
+        assert "<hypernet:v18000Steps:1>" in prompt
+        # but we should expect to see the emphasis added in other words
         assert "(purple" in prompt or "(artistic" in prompt or "(painting" in prompt
         assert ")" in prompt

--- a/tests/generators/test_attentiongenerator.py
+++ b/tests/generators/test_attentiongenerator.py
@@ -5,7 +5,7 @@ from dynamicprompts.generators.attentiongenerator import AttentionGenerator
 @pytest.mark.slow
 def test_default_generator():
     pytest.importorskip("spacy")
-    generator = AttentionGenerator()
+    generator = AttentionGenerator(ignore_special_syntax=True)
     for prompt in generator.generate(
         "purple cat singing opera, artistic, painting "
         "<lora:loraname:0.7> <hypernet:v18000Steps:1>",


### PR DESCRIPTION
Refs https://github.com/adieyal/sd-dynamic-prompts/issues/327

When enabled, we grab any special syntax chunks out of the string before passing it to spaCy, then append them back in. 