### PR TITLE
Initial variable implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The dynamicprompts library powers the [Dynamic Prompts](https://github.com/adiey
       * [Syntax customisation](#syntax-customisation)
     * [Wildcard Collections](#wildcard-collections)
     * [Dynamic Prompts in the wild.](#dynamic-prompts-in-the-wild)
-    
+
 
 
 

--- a/src/dynamicprompts/commands/variable_commands.py
+++ b/src/dynamicprompts/commands/variable_commands.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import dataclasses
+
+from dynamicprompts.commands import Command
+
+
+@dataclasses.dataclass(frozen=True)
+class VariableAssignmentCommand(Command):
+    name: str
+    value: Command
+    immediate: bool
+    sampling_method = None
+
+
+@dataclasses.dataclass(frozen=True)
+class VariableAccessCommand(Command):
+    name: str
+    default: Command | None = None
+    sampling_method = None

--- a/src/dynamicprompts/commands/wildcard_command.py
+++ b/src/dynamicprompts/commands/wildcard_command.py
@@ -10,6 +10,7 @@ from dynamicprompts.enums import SamplingMethod
 class WildcardCommand(Command):
     wildcard: str
     sampling_method: SamplingMethod | None = None
+    variables: dict[str, Command] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
         if not isinstance(self.wildcard, str):

--- a/src/dynamicprompts/parser/config.py
+++ b/src/dynamicprompts/parser/config.py
@@ -6,6 +6,8 @@ class ParserConfig:
     variant_start: str = "{"
     variant_end: str = "}"
     wildcard_wrap: str = "__"
+    variable_start: str = "${"
+    variable_end: str = "}"
 
 
 default_parser_config = ParserConfig()

--- a/src/dynamicprompts/parser/parse.py
+++ b/src/dynamicprompts/parser/parse.py
@@ -29,6 +29,8 @@ sampler_combinatorial = pp.Char("!")
 sampler_cyclical = pp.Char("@")
 sampler_symbol = sampler_random | sampler_combinatorial | sampler_cyclical
 
+OPT_WS = pp.Opt(pp.White())  # Optional whitespace
+
 sampler_symbol_to_method = {
     "~": SamplingMethod.RANDOM,
     "!": SamplingMethod.COMBINATORIAL,
@@ -176,21 +178,18 @@ def _configure_variants(
     variant_end = pp.Suppress(parser_config.variant_end)
 
     variant = pp.Group(
-        pp.Opt(pp.White())
-        + pp.Opt(weight, default=1)("weight")
-        + prompt()("val")
-        + pp.Opt(pp.White()),
+        OPT_WS + pp.Opt(weight, default=1)("weight") + prompt()("val") + OPT_WS,
     )
     variants_list = pp.Group(pp.delimited_list(variant, delim="|"))
 
     variants = pp.Group(
         variant_start
-        + pp.Opt(pp.White())
+        + OPT_WS
         + pp.Opt(sampler_symbol)("sampling_method")
         + pp.Opt(bound_expr)("bound_expr")
-        + pp.Opt(pp.White())
+        + OPT_WS
         + variants_list("variants")
-        + pp.Opt(pp.White())
+        + OPT_WS
         + variant_end,
     )
 

--- a/src/dynamicprompts/parser/parse.py
+++ b/src/dynamicprompts/parser/parse.py
@@ -123,7 +123,7 @@ def _configure_wildcard(
     wildcard_enclosure = pp.Suppress(parser_config.wildcard_wrap)
     wildcard = (
         wildcard_enclosure
-        + pp.Optional(sampler_symbol)("sampling_method")
+        + pp.Opt(sampler_symbol)("sampling_method")
         + wildcard_path
         + wildcard_enclosure
     )
@@ -176,21 +176,21 @@ def _configure_variants(
     variant_end = pp.Suppress(parser_config.variant_end)
 
     variant = pp.Group(
-        pp.Optional(pp.White())
+        pp.Opt(pp.White())
         + pp.Opt(weight, default=1)("weight")
         + prompt()("val")
-        + pp.Optional(pp.White()),
+        + pp.Opt(pp.White()),
     )
     variants_list = pp.Group(pp.delimited_list(variant, delim="|"))
 
     variants = pp.Group(
         variant_start
-        + pp.Optional(pp.White())
-        + pp.Optional(sampler_symbol)("sampling_method")
+        + pp.Opt(pp.White())
+        + pp.Opt(sampler_symbol)("sampling_method")
         + pp.Opt(bound_expr)("bound_expr")
-        + pp.Optional(pp.White())
+        + pp.Opt(pp.White())
         + variants_list("variants")
-        + pp.Optional(pp.White())
+        + pp.Opt(pp.White())
         + variant_end,
     )
 

--- a/src/dynamicprompts/samplers/base.py
+++ b/src/dynamicprompts/samplers/base.py
@@ -92,4 +92,6 @@ class Sampler:
         if not command_to_sample:
             # TODO: do we want to support returning e.g. empty here (c.f. Jinja's "undefined")?
             raise KeyError(f"Variable {variable} is not defined in this context")
-        return context.generator_from_command(command_to_sample)
+        return context.for_sampling_variable(variable).generator_from_command(
+            command_to_sample,
+        )

--- a/src/dynamicprompts/samplers/base.py
+++ b/src/dynamicprompts/samplers/base.py
@@ -90,8 +90,12 @@ class Sampler:
         variable = command.name
         command_to_sample = context.variables.get(variable, command.default)
         if not command_to_sample:
-            # TODO: do we want to support returning e.g. empty here (c.f. Jinja's "undefined")?
-            raise KeyError(f"Variable {variable} is not defined in this context")
+            if context.unknown_variable_value is None:
+                raise KeyError(f"Variable {variable} is not defined in this context")
+            elif isinstance(context.unknown_variable_value, str):
+                command_to_sample = LiteralCommand(context.unknown_variable_value)
+            else:
+                command_to_sample = context.unknown_variable_value
         return context.for_sampling_variable(variable).generator_from_command(
             command_to_sample,
         )

--- a/src/dynamicprompts/samplers/combinatorial.py
+++ b/src/dynamicprompts/samplers/combinatorial.py
@@ -146,6 +146,7 @@ class CombinatorialSampler(Sampler):
         command: WildcardCommand,
         context: SamplingContext,
     ) -> StringGen:
+        context = context.with_variables(command.variables)
         values = context.wildcard_manager.get_all_values(command.wildcard)
         if len(values) == 0:
             logger.warning(f"No values found for wildcard {command.wildcard}")

--- a/src/dynamicprompts/samplers/combinatorial.py
+++ b/src/dynamicprompts/samplers/combinatorial.py
@@ -60,10 +60,9 @@ class CombinatorialSampler(Sampler):
         command: SequenceCommand,
         context: SamplingContext,
     ) -> StringGen:
+        tokens, context = context.process_variable_assignments(command.tokens)
         non_combo_commands = [
-            c
-            for c in command.tokens
-            if c.sampling_method != SamplingMethod.COMBINATORIAL
+            c for c in tokens if c.sampling_method != SamplingMethod.COMBINATORIAL
         ]
         command_collection = CommandCollection(
             non_combo_commands,
@@ -74,7 +73,7 @@ class CombinatorialSampler(Sampler):
                 "",
                 sampling_method=SamplingMethod.COMBINATORIAL,
             ),  # sentinel 1
-            *command.tokens,
+            *tokens,
             LiteralCommand(
                 "",
                 sampling_method=SamplingMethod.COMBINATORIAL,

--- a/src/dynamicprompts/samplers/cycle.py
+++ b/src/dynamicprompts/samplers/cycle.py
@@ -96,7 +96,9 @@ class CyclicalSampler(Sampler):
         sampling_context: SamplingContext,
     ):
         values = sampling_context.wildcard_manager.get_all_values(command.wildcard)
-        new_context = sampling_context.with_sampling_method(SamplingMethod.CYCLICAL)
+        new_context = sampling_context.with_variables(
+            command.variables,
+        ).with_sampling_method(SamplingMethod.CYCLICAL)
         value_samplers = [new_context.sample_prompts(val) for val in values]
         value_string_gens = [to_string_gen(val) for val in value_samplers]
 

--- a/src/dynamicprompts/samplers/random.py
+++ b/src/dynamicprompts/samplers/random.py
@@ -103,6 +103,7 @@ class RandomSampler(Sampler):
         command: WildcardCommand,
         context: SamplingContext,
     ) -> StringGen:
+        context = context.with_variables(command.variables)
         values = context.wildcard_manager.get_all_values(command.wildcard)
 
         if len(values) == 0:

--- a/src/dynamicprompts/sampling_context.py
+++ b/src/dynamicprompts/sampling_context.py
@@ -43,6 +43,10 @@ class SamplingContext:
     rand: Random = DEFAULT_RANDOM
     variables: dict[str, Command] = dataclasses.field(default_factory=dict)
 
+    # Value for variables that aren't defined in the present context.
+    # None will raise an error.
+    unknown_variable_value: str | Command | None = None
+
     # Variables that are currently sampled, to prevent infinite recursion
     _variables_being_sampled: set[str] = dataclasses.field(default_factory=set)
 

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -413,6 +413,10 @@ class TestParser:
                 "(animal=fox,color=red)",
                 {"animal": LiteralCommand("fox"), "color": LiteralCommand("red")},
             ),
+            (
+                "(color={A|B|C})",
+                {"color": VariantCommand.from_literals_and_weights(list("ABC"))},
+            ),
         ],
     )
     def test_wildcard_variable_shorthand(self, var_spec: str, expected_vars: dict):

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -36,7 +36,6 @@ class TestParser:
             "Test (high emphasis)",  # round brackets
             "Test (high emphasis:0.4)",  # round brackets with weight
             "Unmatched } bracket",
-            "$$ are fine outside of variants",
         ],
     )
     def test_literal_characters(self, input: str):

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -403,3 +403,20 @@ class TestParser:
         assert isinstance(acc, VariableAccessCommand)
         assert acc.name == "animal"
         assert acc.default == LiteralCommand("dog")
+
+    @pytest.mark.parametrize(
+        "var_spec, expected_vars",
+        [
+            ("", {}),
+            ("(animal=bear)", {"animal": LiteralCommand("bear")}),
+            (
+                "(animal=fox,color=red)",
+                {"animal": LiteralCommand("fox"), "color": LiteralCommand("red")},
+            ),
+        ],
+    )
+    def test_wildcard_variable_shorthand(self, var_spec: str, expected_vars: dict):
+        cmd = parse(f"__foo{var_spec}__")
+        assert isinstance(cmd, WildcardCommand)
+        assert cmd.wildcard == "foo"
+        assert cmd.variables == expected_vars

--- a/tests/test_data/wildcards/publicprompts/plush-toy.yaml
+++ b/tests/test_data/wildcards/publicprompts/plush-toy.yaml
@@ -1,0 +1,1 @@
+- Cute kawaii Squishy ${animal} plush toy, realistic texture, visible stitch line, soft smooth lighting, vibrant studio lighting, modular constructivism, physically based rendering, square image

--- a/tests/test_variable_features.py
+++ b/tests/test_variable_features.py
@@ -29,3 +29,13 @@ def test_discussion_61(wildcard_manager: WildcardManager):
         if expected == seen:
             break
     assert seen == expected
+
+
+def test_discussion_61_shorthand(wildcard_manager: WildcardManager):
+    cmd = parse("__publicprompts/plush-toy(animal=fox)__")
+    scon = SamplingContext(
+        default_sampling_method=SamplingMethod.RANDOM,
+        wildcard_manager=wildcard_manager,
+    )
+    prompt = next(scon.sample_prompts(cmd))
+    assert prompt.strip().lower().startswith("cute kawaii squishy fox")

--- a/tests/test_variable_features.py
+++ b/tests/test_variable_features.py
@@ -1,0 +1,31 @@
+from itertools import islice
+
+from dynamicprompts.enums import SamplingMethod
+from dynamicprompts.parser.parse import parse
+from dynamicprompts.sampling_context import SamplingContext
+from dynamicprompts.wildcards import WildcardManager
+
+
+def test_discussion_61(wildcard_manager: WildcardManager):
+    cmd = parse("${animal={fox|manatee}} __publicprompts/plush-toy__")
+    scon = SamplingContext(
+        # TODO: a COMBINATORIAL sampling method does not yet propagate
+        #       into sampling the expanded wildcard, (IOW, with a
+        #       COMBINATORIAL context, this test should also result in
+        #       two prompts, one for a fox and one for a manatee).
+        default_sampling_method=SamplingMethod.RANDOM,
+        wildcard_manager=wildcard_manager,
+    )
+
+    gen = scon.sample_prompts(cmd)
+    seen = set()
+    expected = {"fox", "manatee"}
+    for prompt in islice(gen, 10):
+        prompt = prompt.strip().lower()
+        assert prompt.startswith("cute kawaii squishy")
+        for ex in expected:
+            if ex in prompt:
+                seen.add(ex)
+        if expected == seen:
+            break
+    assert seen == expected

--- a/tests/wildcard/test_wildcardmanager.py
+++ b/tests/wildcard/test_wildcardmanager.py
@@ -68,7 +68,7 @@ def test_get_all_values_with_missing_wildcard(wildcard_manager: WildcardManager)
 
 def test_hierarchy(wildcard_manager: WildcardManager):
     root = wildcard_manager.tree.root
-    assert len(list(root.walk_items())) == 14
+    assert len(list(root.walk_items())) == 15
     assert set(root.collections) == {
         "clothing",  # from pantry YAML
         "colors-cold",  # .txt


### PR DESCRIPTION
This PR is the initial implementation of _variables_ for prompts, as discussed in https://github.com/adieyal/dynamicprompts/discussions/61.

# Notes

* The basic syntax is e.g. `${color=red} The sky was ${color} tonight`.
* Variable assignments are (currently) evaluated before any other command in the same sequence; `${color=red} The sky was ${color} tonight ${color=blue}` will yield a blue sky. (This could be changed, but will require us to e.g. split SequenceCommands into sub-sequences on each assignment, and could get hairy.)
* One can nest other commands into the variable assignment's rvalue: `${color={red|blue}}`. 
* By default, the variable holds a reference to the rvalue command as-is, i.e. `${color={red|blue}} ${color} ${color}` in a random sampling context can return two different colors.
* One can force the evaluation of a variable into a literal command immediately with a bang: `${color=!{red|blue}} ${color} ${color}` will then always yield `red red` or `blue blue`.
* There's a shorthand syntax for the common case of setting a simple variable (or multiple) to use in a wildcard reference: `__wildcard(color=red,shape=bouba)__`. This currently _only_ supports literals; you can't use command or other syntax in these. You also can't use a comma or a closing paren in the value.

# Issues (?)

* There is a known issue (marked TODO in the test): `${animal={fox|manatee}} __publicprompts/plush-toy__` will currently **not** generate two plush toys. I've yet to figure out quite why. This could be merged nevertheless...

