### PR TITLE
Fixed wildcard variants with nested prompts

### DIFF
--- a/src/dynamicprompts/samplers/utils.py
+++ b/src/dynamicprompts/samplers/utils.py
@@ -1,28 +1,27 @@
-from dynamicprompts.commands import (
-    VariantCommand,
-    WildcardCommand,
-)
+from dynamicprompts.commands import VariantCommand, VariantOption, WildcardCommand
+from dynamicprompts.parser.parse import parse
 from dynamicprompts.sampling_context import SamplingContext
 
 
 def wildcard_to_variant(
-    wildcard: WildcardCommand,
+    command: WildcardCommand,
     *,
     context: SamplingContext,
     min_bound=1,
     max_bound=1,
     separator=",",
 ) -> VariantCommand:
-    wm = context.wildcard_manager
-    wildcard_values = wm.get_all_values(wildcard.wildcard)
-    min_bound = min(min_bound, len(wildcard_values))
-    max_bound = min(max_bound, len(wildcard_values))
+    values = context.wildcard_manager.get_all_values(command.wildcard)
+    min_bound = min(min_bound, len(values))
+    max_bound = min(max_bound, len(values))
 
-    wildcard_variant = VariantCommand.from_literals_and_weights(
-        wildcard_values,
-        min_bound=min_bound,
-        max_bound=max_bound,
-        separator=separator,
-        sampling_method=wildcard.sampling_method,
+    variant_options = [VariantOption(parse(v)) for v in values]
+
+    wildcard_variant = VariantCommand(
+        variant_options,
+        min_bound,
+        max_bound,
+        separator,
+        command.sampling_method,
     )
     return wildcard_variant

--- a/tests/test_sd_issues.py
+++ b/tests/test_sd_issues.py
@@ -102,3 +102,14 @@ def test_dp_28():
             for p in prompts
         ],
     )
+
+
+def test_sd_358(wildcard_manager: WildcardManager):
+    generator = RandomPromptGenerator(wildcard_manager)
+    prompts = generator.generate("{2$$__referencing-colors__}", 2)
+    colors = wildcard_manager.get_all_values(
+        "colors-cold",
+    ) + wildcard_manager.get_all_values("colors-warm")
+    combinations = [f"{c1},{c2}" for c1 in colors for c2 in colors if c1 != c2]
+    # check the every prompt is a combination of two colors
+    assert all(p in combinations for p in prompts)


### PR DESCRIPTION
If colours.txt contained
__colours-warm__
__colours-cold__

Then {2$$__colours__} would treat those nested wildcards as strings