### PR TITLE
Optimize parsing

### DIFF
--- a/src/dynamicprompts/parser/config.py
+++ b/src/dynamicprompts/parser/config.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
 
+# NB: this class needs to remain `frozen`, because it's used
+#     as a key for `get_cached_parser`'s weak-key dictionary.
 @dataclass(frozen=True)
 class ParserConfig:
     variant_start: str = "{"

--- a/src/dynamicprompts/parser/parse.py
+++ b/src/dynamicprompts/parser/parse.py
@@ -450,6 +450,8 @@ def parse(
     :param prompt: The prompt string to parse.
     :return: A command representing the parsed prompt.
     """
+    if prompt.isalnum():  # no need to actually parse anything
+        return LiteralCommand(prompt)
 
     tokens = create_parser(parser_config=parser_config).parse_string(
         prompt,


### PR DESCRIPTION
I realized we

* don't need to even invoke PyParsing if the command is obviously just a word (common in e.g. wildcards!)
* don't need to re-create parsers when the configuration hasn't changed; we can cache them by `ParserConfig`.

– the speed increase for a `-k "not slow`" test suite is pretty shocking (roughly 4x faster) 😁 

```
(dynamicprompts) ~/b/dynamicprompts (main) $ hyperfine 'py.test -k "not slow"' -i -m 2
Benchmark 1: py.test -k "not slow"
  Time (mean ± σ):     14.112 s ±  0.428 s    [User: 14.190 s, System: 0.582 s]
  Range (min … max):   13.809 s … 14.415 s    2 runs
(dynamicprompts) ~/b/dynamicprompts (optimize-parse) $ hyperfine 'py.test -k "not slow"' -i -m 2
Benchmark 1: py.test -k "not slow"
  Time (mean ± σ):      3.681 s ±  0.009 s    [User: 4.088 s, System: 0.436 s]
  Range (min … max):    3.674 s …  3.687 s    2 runs
```