### PR TITLE
Make wildcard lookup fall back to searching everywhere in the hierarchy

### DIFF
--- a/src/dynamicprompts/samplers/combinatorial.py
+++ b/src/dynamicprompts/samplers/combinatorial.py
@@ -14,7 +14,10 @@ from dynamicprompts.commands import (
 )
 from dynamicprompts.samplers.base import Sampler
 from dynamicprompts.samplers.command_collection import CommandCollection
-from dynamicprompts.samplers.utils import wildcard_to_variant
+from dynamicprompts.samplers.utils import (
+    get_wildcard_not_found_fallback,
+    wildcard_to_variant,
+)
 from dynamicprompts.sampling_context import SamplingContext
 from dynamicprompts.types import StringGen
 
@@ -148,8 +151,9 @@ class CombinatorialSampler(Sampler):
     ) -> StringGen:
         context = context.with_variables(command.variables)
         values = context.wildcard_manager.get_all_values(command.wildcard)
-        if len(values) == 0:
-            logger.warning(f"No values found for wildcard {command.wildcard}")
+        if not values:
+            yield from get_wildcard_not_found_fallback(command, context)
+            return
 
         for val in values:
             # Parse and generate prompts from wildcard value

--- a/src/dynamicprompts/samplers/random.py
+++ b/src/dynamicprompts/samplers/random.py
@@ -9,7 +9,10 @@ from dynamicprompts.commands import (
     WildcardCommand,
 )
 from dynamicprompts.samplers.base import Sampler
-from dynamicprompts.samplers.utils import wildcard_to_variant
+from dynamicprompts.samplers.utils import (
+    get_wildcard_not_found_fallback,
+    wildcard_to_variant,
+)
 from dynamicprompts.sampling_context import SamplingContext
 from dynamicprompts.types import StringGen
 from dynamicprompts.utils import choose_without_replacement, rotate_and_join
@@ -107,11 +110,9 @@ class RandomSampler(Sampler):
         values = context.wildcard_manager.get_all_values(command.wildcard)
 
         if len(values) == 0:
-            logger.warning(f"No values found for wildcard {command.wildcard}")
+            yield from get_wildcard_not_found_fallback(command, context)
+            return
 
         while True:
-            if len(values) == 0:
-                yield context.wildcard_manager.to_wildcard(command.wildcard)
-            else:
-                value = self._get_wildcard_choice(context, values)
-                yield from context.sample_prompts(value, 1)
+            value = self._get_wildcard_choice(context, values)
+            yield from context.sample_prompts(value, 1)

--- a/src/dynamicprompts/samplers/utils.py
+++ b/src/dynamicprompts/samplers/utils.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+
+import logging
+
 from dynamicprompts.commands import VariantCommand, VariantOption, WildcardCommand
 from dynamicprompts.parser.parse import parse
 from dynamicprompts.sampling_context import SamplingContext
+from dynamicprompts.types import StringGen
+
+logger = logging.getLogger(__name__)
 
 
 def wildcard_to_variant(
@@ -27,3 +34,16 @@ def wildcard_to_variant(
         command.sampling_method,
     )
     return wildcard_variant
+
+
+def get_wildcard_not_found_fallback(
+    command: WildcardCommand,
+    context: SamplingContext,
+) -> StringGen:
+    """
+    Logs a warning, then infinitely yields the wrapped wildcard.
+    """
+    logger.warning(f"No values found for wildcard {command.wildcard}")
+    wrapped_wildcard = context.wildcard_manager.to_wildcard(command.wildcard)
+    while True:
+        yield wrapped_wildcard

--- a/src/dynamicprompts/wildcards/wildcard_manager.py
+++ b/src/dynamicprompts/wildcards/wildcard_manager.py
@@ -122,4 +122,18 @@ class WildcardManager:
         values: set[str] = set()
         for f in self.match_collections(wildcard):
             values.update(f.get_values())
+        if not values and not wildcard.startswith("**"):
+            # If the wildcard doesn't match anything, try again with a recursive wildcard
+            rec_wildcard = f"**/{wildcard}"
+            rec_colls = list(self.match_collections(rec_wildcard))
+            for f in rec_colls:
+                values.update(f.get_values())
+            if values:
+                logger.warning(
+                    "No matches for wildcard %r, used %r to match %s",
+                    wildcard,
+                    rec_wildcard,
+                    ", ".join(str(coll) for coll in rec_colls),
+                )
+
         return sorted(values)

--- a/tests/test_data/wildcards/animals/all-references.txt
+++ b/tests/test_data/wildcards/animals/all-references.txt
@@ -1,0 +1,5 @@
+# These refer to files within this directory.
+
+__mammals/canine__
+__mammals/feline__
+__mystical__

--- a/tests/wildcard/test_wildcardmanager.py
+++ b/tests/wildcard/test_wildcardmanager.py
@@ -70,6 +70,7 @@ def test_get_all_values_with_missing_wildcard(wildcard_manager: WildcardManager)
 def test_hierarchy(wildcard_manager: WildcardManager):
     root = wildcard_manager.tree.root
     assert {name for name, item in root.walk_items()} == {
+        "animals/all-references",
         "animals/mammals/canine",
         "animals/mammals/feline",
         "animals/mystical",
@@ -94,12 +95,16 @@ def test_hierarchy(wildcard_manager: WildcardManager):
         "shapes",  # flat list YAML
         "variant",  # .txt
     }
-    assert set(root.child_nodes["animals"].collections) == {"mystical"}
+    assert set(root.child_nodes["animals"].collections) == {
+        "all-references",
+        "mystical",
+    }
     assert set(root.child_nodes["animals"].child_nodes["mammals"].collections) == {
         "canine",
         "feline",
     }
     assert set(root.child_nodes["animals"].walk_full_names()) == {
+        "animals/all-references",
         "animals/mammals/canine",
         "animals/mammals/feline",
         "animals/mystical",
@@ -269,6 +274,7 @@ def test_wcm_roots():
     assert wcm.get_collection_names() == {
         "finnish-words",
         "elaimet/jannat",
+        "elaimet/all-references",
         "elaimet/mammals/canine",
         "elaimet/mammals/feline",
         "elaimet/mystical",
@@ -276,7 +282,7 @@ def test_wcm_roots():
         "metasyntactic/fnord",
         "metasyntactic/foo",
     }
-    assert set(wcm.get_all_values("elaimet/*")) == {
+    assert {v for v in wcm.get_all_values("elaimet/*") if not v.startswith("_")} == {
         "cat",
         "dog",
         "okapi",


### PR DESCRIPTION
Workaround for https://github.com/adieyal/sd-dynamic-prompts/issues/377.

This was an easier fix than actually doing search paths (since e.g. `wildcard_to_variant` makes that really messy).