### PR TITLE
Correct wildcard manager import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ If you want to use wildcards, instantiate a WildcardManager:
 ```python
 from pathlib import Path
 from dynamicprompts.generators import RandomPromptGenerator
-from dynamicprompts.wildcardmanager import WildcardManager
+from dynamicprompts.wildcards.wildcard_manager import WildcardManager
 
 wm = WildcardManager(Path("/path/to/wildcard/directory"))
 


### PR DESCRIPTION
Just a small fix to the README.