### PR TITLE
Allow attention generator to work without Spacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,11 +390,11 @@ attention_generator.generate(prompt, num_prompts=1)
 
 <img src="images/emphasis.png">
 
-Note, AttentionGenerator is not installed by default as it needs additional libraries to run. Use this command to install it:
+You may get better results with AttentionGenerator by installing the `spacy` NLP library. Use this command to install it:
 
-`pip install "dynamicprompts[attentiongrabber]"`
+`pip install spacy`
 
-One your first use it, a model will automatically be downloaded.
+When Spacy is available, an NLP model will automatically be downloaded on first use.
 
 ## Jinja2 templates
 If the standard template language is not sufficient for your needs, you can try the Jinja2 generator. Jinja2 templates have familiar programming constructs such as looping, conditionals, variables, etc. Youcan find a guide on using Jinja2 templates with Dynamic Prompts, [here](https://github.com/adieyal/sd-dynamic-prompts/blob/main/jinja2.md). Here is the minimal code you need to instantiate Jinja2 generator.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-attentiongrabber = ["spacy~=3.4"]
+attentiongrabber = []  # empty list for backwards compatibility (no "no extra" warnings)
 magicprompt = ["transformers[torch]~=4.19"]
 feelinglucky = ["requests~=2.28"]
 dev = [
@@ -79,6 +79,10 @@ exclude = "tests"
 
 [[tool.mypy.overrides]]
 module = "transformers"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "spacy.*"
 ignore_missing_imports = true
 
 [tool.coverage.report]

--- a/src/dynamicprompts/generators/attentiongenerator.py
+++ b/src/dynamicprompts/generators/attentiongenerator.py
@@ -2,13 +2,73 @@ from __future__ import annotations
 
 import logging
 import random
+import re
+import string
+import warnings
+from functools import lru_cache
+from typing import Callable
 
 from dynamicprompts.generators.dummygenerator import DummyGenerator
 from dynamicprompts.generators.promptgenerator import PromptGenerator
 
 logger = logging.getLogger(__name__)
 
-MODEL_NAME = "en_core_web_sm"
+
+def is_valid_chunk(chunk: str) -> bool:
+    if chunk.isdigit():
+        return False
+    if all(c in string.punctuation for c in chunk):
+        return False
+    return True
+
+
+def cheap_chunker(prompt: str) -> list[str]:
+    """
+    A cheap noun chunker that splits on punctuation and the like.
+    """
+    return [
+        chunk
+        for chunk in re.split(r"\s*[,;:.?!()]+\s*", prompt.strip())
+        if is_valid_chunk(chunk)
+    ]
+
+
+def get_spacy_chunker(spacy_model_name="en_core_web_sm") -> Callable[[str], list[str]]:
+    import spacy
+
+    try:
+        spacy.load(spacy_model_name)
+    except OSError:
+        logger.info("Spacy model not found, downloading...")
+        from spacy.cli.download import download
+
+        download(spacy_model_name)
+    _nlp = spacy.load(spacy_model_name)
+    return lambda prompt: [str(chunk) for chunk in _nlp(prompt).noun_chunks]
+
+
+@lru_cache(maxsize=1)
+def get_chunker() -> Callable[[str], list[str]]:
+    """
+    Get a noun chunker. If spacy is installed, use that, otherwise use a cheap built-in one.
+    """
+    try:
+        return get_spacy_chunker()
+    except ImportError:
+        warnings.warn(
+            "Could not import spacy, using cheap built-in NLP. "
+            "For possibly better results, `pip install spacy`.",
+        )
+        return cheap_chunker
+
+
+@lru_cache(maxsize=10)
+def find_noun_chunks(text: str) -> tuple[str, ...]:
+    """
+    Find noun chunks in a string.
+    Results are cached; returns an immutable tuple.
+    """
+    return tuple(get_chunker()(text))
 
 
 class AttentionGenerator(PromptGenerator):
@@ -20,35 +80,14 @@ class AttentionGenerator(PromptGenerator):
         min_attention: float = 0.1,
         max_attention: float = 0.9,
     ) -> None:
-        try:
-            import spacy
-        except ImportError as ie:
-            raise ImportError(
-                "Could not import spacy, attention generator will not work. "
-                "Install with pip install dynamicprompts[attentiongrabber]",
-            ) from ie
-        try:
-            spacy.load(MODEL_NAME)
-        except OSError:
-            logger.warning("Spacy model not found, downloading...")
-            from spacy.cli.download import download
-
-            download(MODEL_NAME)
-
-        self._nlp = spacy.load(MODEL_NAME)
-
-        if generator is None:
-            self._generator = DummyGenerator()
-        else:
-            self._generator = generator
-
-        m, M = min(min_attention, max_attention), max(min_attention, max_attention)
-        self._min_attention, self._max_attention = m, M
+        self._generator = generator or DummyGenerator()
+        self._min_attention, self._max_attention = sorted(
+            (min_attention, max_attention),
+        )
 
     def _add_emphasis(self, prompt: str) -> str:
-        doc = self._nlp(prompt)
-        keywords = list(doc.noun_chunks)
-        if len(keywords) == 0:
+        keywords = find_noun_chunks(prompt)
+        if not keywords:
             return prompt
 
         keyword = random.choice(keywords)

--- a/tests/generators/test_attentiongenerator.py
+++ b/tests/generators/test_attentiongenerator.py
@@ -1,13 +1,26 @@
 from unittest.mock import MagicMock
 
 import pytest
-from dynamicprompts.generators.attentiongenerator import AttentionGenerator
+from dynamicprompts.generators.attentiongenerator import (
+    AttentionGenerator,
+    cheap_chunker,
+)
 
 
 @pytest.fixture
 def generator():
-    pytest.importorskip("spacy")
     return AttentionGenerator()
+
+
+def test_cheap_chunker():
+    assert cheap_chunker(
+        "purple cat singing opera, artistic, painting (best quality:1.3)",
+    ) == [
+        "purple cat singing opera",
+        "artistic",
+        "painting",
+        "best quality",
+    ]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
This makes the attention generator use a cheap and cheerful chunker that should probably work adequately for many prompts, if spaCy is not installed.
