### PR TITLE
Drop pytest-mock in favor of standard library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ feelinglucky = ["requests~=2.28"]
 dev = [
     "pytest-cov~=4.0",
     "pytest-lazy-fixture~=0.6",
-    "pytest-mock~=3.10",
     "pytest~=7.2",
 ]
 

--- a/tests/generators/test_batched_combinatorial.py
+++ b/tests/generators/test_batched_combinatorial.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 from dynamicprompts import constants
 from dynamicprompts.generators.batched_combinatorial import (
     BatchedCombinatorialPromptGenerator,
@@ -5,8 +7,8 @@ from dynamicprompts.generators.batched_combinatorial import (
 from dynamicprompts.generators.promptgenerator import PromptGenerator
 
 
-def test_single_batch(mocker):
-    mock_generator = mocker.MagicMock(PromptGenerator)
+def test_single_batch():
+    mock_generator = MagicMock(PromptGenerator)
     mock_generator.generate.return_value = ["image1", "image2"]
     generator = BatchedCombinatorialPromptGenerator(mock_generator, batches=1)
     images = generator.generate("template")
@@ -14,8 +16,8 @@ def test_single_batch(mocker):
     mock_generator.generate.assert_called_once_with("template", constants.MAX_IMAGES)
 
 
-def test_multiple_batches(mocker):
-    mock_generator = mocker.MagicMock(PromptGenerator)
+def test_multiple_batches():
+    mock_generator = MagicMock(PromptGenerator)
     mock_generator.generate.return_value = ["image1", "image2"]
     generator = BatchedCombinatorialPromptGenerator(mock_generator, batches=3)
     images = generator.generate("template")
@@ -23,15 +25,15 @@ def test_multiple_batches(mocker):
     assert mock_generator.generate.call_count == 3
 
 
-def test_max_prompts_passed_correctly(mocker):
-    mock_generator = mocker.MagicMock(PromptGenerator)
+def test_max_prompts_passed_correctly():
+    mock_generator = MagicMock(PromptGenerator)
     generator = BatchedCombinatorialPromptGenerator(mock_generator, batches=1)
     generator.generate("template", max_prompts=5)
     mock_generator.generate.assert_called_once_with("template", 5)
 
 
-def test_generate_accepts_kwargs(mocker):
-    mock_generator = mocker.MagicMock(PromptGenerator)
+def test_generate_accepts_kwargs():
+    mock_generator = MagicMock(PromptGenerator)
     generator = BatchedCombinatorialPromptGenerator(mock_generator, batches=1)
     generator.generate("template", max_prompts=5, extra_arg="value")
     mock_generator.generate.assert_called_once_with("template", 5, extra_arg="value")

--- a/tests/generators/test_combinatorial.py
+++ b/tests/generators/test_combinatorial.py
@@ -97,7 +97,7 @@ class TestCombinatorialGenerator:
         assert generator._context.wildcard_manager.path is None
 
 
-def test_generate_accepts_kwargs(mocker):
+def test_generate_accepts_kwargs():
     generator = CombinatorialPromptGenerator()
     generator.generate("template", max_prompts=5, extra_arg="value")
     # shouldn't raise an exception

--- a/tests/generators/test_feelinglucky.py
+++ b/tests/generators/test_feelinglucky.py
@@ -1,28 +1,30 @@
+from unittest.mock import Mock, patch
+
 import pytest
 from dynamicprompts.generators import DummyGenerator, FeelingLuckyGenerator
 
 
 @pytest.fixture
-def mock_generator(mocker):
-    mock = mocker.Mock()
+def mock_generator():
+    mock = Mock()
     mock.generate.return_value = ["Prompt"]
     return mock
 
 
 @pytest.fixture
-def mock_requests(mocker):
-    mock = mocker.patch("dynamicprompts.generators.feelinglucky.query_lexica")
-    mock.return_value = {
-        "images": [{"prompt": "ABC"}, {"prompt": "XYZ"}],
-    }
-    return mock
+def mock_requests():
+    with patch("dynamicprompts.generators.feelinglucky.query_lexica") as mock:
+        mock.return_value = {
+            "images": [{"prompt": "ABC"}, {"prompt": "XYZ"}],
+        }
+        yield mock
 
 
 @pytest.fixture
-def mock_random(mocker):
-    mock = mocker.patch("dynamicprompts.generators.feelinglucky.random")
-    mock.choices.return_value = [{"prompt": "ABC"}]
-    return mock
+def mock_random():
+    with patch("dynamicprompts.generators.feelinglucky.random") as mock:
+        mock.choices.return_value = [{"prompt": "ABC"}]
+        yield mock
 
 
 def test_default_generator():


### PR DESCRIPTION
Down with unnecessary dependencies! 😁 

[py.test has a built-in `monkeypatch` fixture](https://docs.pytest.org/en/7.1.x/how-to/monkeypatch.html), and `unittest.mock.patch` can easily be used with a yielding fixture.