### PR TITLE
Magic prompt: fix device typing, don't specify it by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,10 @@ from dynamicprompts.generators import RandomPromptGenerator
 from dynamicprompts.generators.magicprompt import MagicPromptGenerator
 
 generator = RandomPromptGenerator()
-magic_generator = MagicPromptGenerator(generator, device=0) # device = 0 for CUDA or -1 for CPU
+magic_generator = MagicPromptGenerator(
+    generator,
+    device=...,  # Torch device specifier (int, string, torch.device)
+)
 
 num_prompts = 5
 generator.generate("I love {red|green|blue} roses", num_prompts)

--- a/src/dynamicprompts/generators/magicprompt.py
+++ b/src/dynamicprompts/generators/magicprompt.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import TYPE_CHECKING
 
 from dynamicprompts.generators.dummygenerator import DummyGenerator
 from dynamicprompts.generators.promptgenerator import PromptGenerator
@@ -21,6 +22,9 @@ except ImportError as ie:
         "You need to install the transformers library to use the MagicPrompt generator. "
         "You can do this by running `pip install -U dynamicprompts[magicprompt]`.",
     ) from ie
+
+if TYPE_CHECKING:
+    import torch
 
 DEFAULT_MODEL_NAME = "Gustavosta/MagicPrompt-Stable-Diffusion"
 MAX_SEED = 2**32 - 1
@@ -100,13 +104,25 @@ class MagicPromptGenerator(PromptGenerator):
         self,
         prompt_generator: PromptGenerator | None = None,
         model_name: str = DEFAULT_MODEL_NAME,
-        device: int = -1,
+        device: int | str | torch.device | None = None,
         max_prompt_length: int = 100,
         temperature: float = 0.7,
         seed: int | None = None,
         blocklist_regex: str | None = None,
         batch_size: int = 1,
     ) -> None:
+        """
+        :param prompt_generator: The inner prompt generator to use.
+        :param model_name: The name of the model to use. Defaults to `"Gustavosta/MagicPrompt-Stable-Diffusion"`.
+        :param device:
+            Defines the device (*e.g.*, `"cpu"`, `"cuda:1"`, `"mps"`, or a GPU ordinal rank like `1`) on which
+            the model should be loaded.
+        :param max_prompt_length: The maximum length of the prompt to generate.
+        :param temperature: The sampling temperature to use when generating prompts.
+        :param seed: The seed to use when generating prompts.
+        :param blocklist_regex: A regex to use to filter out prompts that match it.
+        :param batch_size: The batch size to use when generating prompts.
+        """
         self._device = device
         self.set_model(model_name)
 

--- a/tests/generators/test_magicprompt.py
+++ b/tests/generators/test_magicprompt.py
@@ -18,9 +18,6 @@ class TestMagicPrompt:
         generator = MagicPromptGenerator()
         assert isinstance(generator._prompt_generator, DummyGenerator)
 
-        CPU = -1
-        assert generator._device == CPU
-
 
 @pytest.mark.parametrize(
     "original_prompt",


### PR DESCRIPTION
I noticed the typing was "integer only", and defaulted to CPU, so I figured we could let Transformers decide instead.

Might help with https://github.com/adieyal/sd-dynamic-prompts/issues/302