### PR TITLE
Weighted wildcards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7"]  # minimum supported version
+        python-version: ["3.8"]  # minimum supported version
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.8"]  # minimum supported version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,15 +13,16 @@ authors = [
 license = "MIT"
 readme = "README.md"
 keywords = ["stable diffusion", "prompt engineering", "automatic1111", "text2img"]
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Text Processing"
 ]
 dependencies = [
@@ -46,7 +47,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py38"
 select = [
     "B",
     "C",

--- a/src/dynamicprompts/samplers/combinatorial.py
+++ b/src/dynamicprompts/samplers/combinatorial.py
@@ -149,13 +149,14 @@ class CombinatorialSampler(Sampler):
         command: WildcardCommand,
         context: SamplingContext,
     ) -> StringGen:
+        # TODO: doesn't support weights
         context = context.with_variables(command.variables)
-        values = context.wildcard_manager.get_all_values(command.wildcard)
+        values = context.wildcard_manager.get_values(command.wildcard)
         if not values:
             yield from get_wildcard_not_found_fallback(command, context)
             return
 
-        for val in values:
+        for val in values.iterate_string_values_weighted():
             # Parse and generate prompts from wildcard value
             yield from context.sample_prompts(val)
 

--- a/src/dynamicprompts/samplers/utils.py
+++ b/src/dynamicprompts/samplers/utils.py
@@ -18,12 +18,13 @@ def wildcard_to_variant(
     max_bound=1,
     separator=",",
 ) -> VariantCommand:
-    values = context.wildcard_manager.get_all_values(command.wildcard)
+    values = context.wildcard_manager.get_values(command.wildcard)
     min_bound = min(min_bound, len(values))
     max_bound = min(max_bound, len(values))
 
     variant_options = [
-        VariantOption(parse(v, parser_config=context.parser_config)) for v in values
+        VariantOption(parse(v, parser_config=context.parser_config))
+        for v in values.iterate_string_values_weighted()
     ]
 
     wildcard_variant = VariantCommand(

--- a/src/dynamicprompts/wildcards/collection/base.py
+++ b/src/dynamicprompts/wildcards/collection/base.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Iterable
 
+from dynamicprompts.wildcards.item import WildcardItem
+
 
 class WildcardCollection(ABC):
     """
@@ -10,7 +12,7 @@ class WildcardCollection(ABC):
     """
 
     @abstractmethod
-    def get_values(self) -> Iterable[str]:
+    def get_values(self) -> Iterable[str | WildcardItem]:
         """
         Get the contents of this collection.
         """

--- a/src/dynamicprompts/wildcards/collection/list.py
+++ b/src/dynamicprompts/wildcards/collection/list.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any
+from typing import Any, Sequence
 
 from dynamicprompts.wildcards.collection.base import WildcardCollection
+from dynamicprompts.wildcards.item import WildcardItem
 
 
 @dataclasses.dataclass(frozen=True)
@@ -15,10 +16,10 @@ class ListWildcardCollection(WildcardCollection):
     a structured pantry JSON/YAML file.
     """
 
-    entries: list[str]
+    entries: Sequence[str | WildcardItem]
 
     # Implementation-specific hint for the source of the wildcards.
     source: Any = None
 
-    def get_values(self) -> list[str]:
+    def get_values(self) -> Sequence[str | WildcardItem]:
         return self.entries

--- a/src/dynamicprompts/wildcards/collection/structured.py
+++ b/src/dynamicprompts/wildcards/collection/structured.py
@@ -4,13 +4,43 @@ import json
 import logging
 import warnings
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 from dynamicprompts.constants import DEFAULT_ENCODING
 from dynamicprompts.wildcards.collection.base import WildcardCollection
 from dynamicprompts.wildcards.collection.list import ListWildcardCollection
+from dynamicprompts.wildcards.item import WildcardItem
 
 log = logging.getLogger(__name__)
+
+
+def _parse_structured_file_list(value: list[Any]) -> Iterable[str | WildcardItem]:
+    """
+    Parse a single list in a structured file (JSON or YAML) and yield the wildcard items.
+    """
+    for item in value:
+        if not item:
+            continue
+        if isinstance(item, str):
+            # See if we have a `1.1::foo` shorthand
+            weight_text, _, content = item.rpartition("::")
+            try:
+                yield WildcardItem(content=content, weight=float(weight_text))
+            except ValueError:
+                yield content
+            continue
+        elif isinstance(item, dict):
+            # Support {"text": "foo", "weight": 1.1} syntax
+            #     and {"content": "foo", "weight": 1.1}
+            weight = float(item.get("weight", 1))
+            content = item.get("text") or item.get("content") or ""
+            if content:
+                if weight == 1:
+                    yield content
+                else:
+                    yield WildcardItem(content=content, weight=weight)
+                continue
+        log.warning("Unsupported list item: %s", item)
 
 
 def _parse_structured_file_dict(
@@ -27,11 +57,16 @@ def _parse_structured_file_dict(
             continue
         prefix_and_name = (*prefix, name)
         name = "/".join(prefix_and_name)
-        if isinstance(value, list) and all(isinstance(x, str) for x in value):
-            yield (
-                name,
-                ListWildcardCollection(entries=value, source=(file_path, name)),
-            )
+        if isinstance(value, list):
+            try:
+                entries = list(_parse_structured_file_list(value))
+            except Exception:
+                log.warning("Unable to parse key %s in %s", name, file_path)
+            else:
+                yield (
+                    name,
+                    ListWildcardCollection(entries=entries, source=(file_path, name)),
+                )
         elif isinstance(value, dict):
             yield from _parse_structured_file_dict(
                 value,

--- a/src/dynamicprompts/wildcards/item.py
+++ b/src/dynamicprompts/wildcards/item.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WildcardItem:
+    content: str
+    weight: float = 1.0
+
+    def __str__(self) -> str:
+        # Will make comparing with strings easier
+        return self.content

--- a/src/dynamicprompts/wildcards/values.py
+++ b/src/dynamicprompts/wildcards/values.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import dataclasses
+import itertools
+import random
+from functools import cached_property
+from typing import Iterable, Iterator
+
+from dynamicprompts.wildcards.item import WildcardItem
+
+
+@dataclasses.dataclass(frozen=True)
+class WildcardValues:
+    """
+    Collection of wildcard values; has a flag for whether any value may have
+    varied weights, and as such requires special weighted sampling too.
+
+    Immutable.
+    """
+
+    items: tuple[str | WildcardItem, ...]
+
+    def __iter__(self) -> Iterable[str | WildcardItem]:
+        return iter(self.items)
+
+    def __getitem__(self, item) -> str | WildcardItem:
+        return self.items[item]
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __bool__(self) -> bool:
+        return bool(self.items)
+
+    def __add__(self, other: WildcardValues) -> WildcardValues:
+        """
+        Combine two WildcardValues collections.
+        """
+        if not isinstance(other, WildcardValues):
+            raise TypeError(f"Cannot add WildcardValues and {type(other)}")
+        return WildcardValues.from_items(self.items + other.items)
+
+    @cached_property
+    def has_varied_weights(self) -> bool:
+        """
+        Whether the weights of the items in this collection vary.
+
+        Users can use this to avoid a weighted random generator if they know
+        that all the weights are the same.
+        """
+        weights_seen = set()
+        for item in self.items:
+            weight = getattr(item, "weight", 1)
+            weights_seen.add(weight)
+            if len(weights_seen) > 1:
+                return True
+        return False
+
+    @cached_property
+    def string_values(self) -> list[str]:
+        """
+        String values, no weights, of the items in this collection.
+        """
+        return [str(item) for item in self.items]
+
+    @cached_property
+    def cum_weight_values(self) -> list[float]:
+        """
+        Cumulative weights of the items in this collection.
+        """
+        weights = [getattr(item, "weight", 1) for item in self.items]
+        return list(itertools.accumulate(weights))
+
+    def copy(self) -> WildcardValues:
+        return dataclasses.replace(self, items=tuple(self.items))
+
+    def shuffled(self, rng=random) -> WildcardValues:
+        """
+        Return a shuffled copy of this collection.
+        """
+        items = list(self.items)
+        rng.shuffle(items)
+        return dataclasses.replace(self, items=tuple(items))
+
+    @classmethod
+    def from_items(cls, wildcards: Iterable[str | WildcardItem]) -> WildcardValues:
+        """
+        Create a WildcardValues collection from an iterable of items (strings or WildcardItems).
+        """
+        return cls(tuple(wildcards))
+
+    def iterate_string_values_weighted(self) -> Iterator[str]:
+        """
+        Iterate over the string values, repeating each one according to its weight.
+
+        Decimal weights are truncated down to integers.
+        """
+        # TODO: right now this does repeat each item according to weight,
+        #       e.g. `A A A B B C [...]`, but maybe it should do `A B C A B A [...]` instead?
+        for item in self.items:
+            weight = getattr(item, "weight", 1)
+            for _ in range(int(weight)):
+                yield str(item)
+
+    def get_weighted_random_generator(self, rng: random.Random) -> Iterator[str]:
+        """
+        Get a generator that yields random values from the wildcard collection.
+
+        If any values have weights, they will be picked according to their weight.
+        """
+        if not self.has_varied_weights:
+            # Simple case: just a random choice
+            while True:
+                yield rng.choice(self.string_values)
+        else:
+            cum_weights = self.cum_weight_values
+            while True:
+                # Grab a bunch (but not too many) random values at a time,
+                # to reduce the number of calls to `choices`.
+                yield from rng.choices(
+                    self.string_values,
+                    cum_weights=cum_weights,
+                    k=10,
+                )

--- a/tests/generators/test_combinatorial.py
+++ b/tests/generators/test_combinatorial.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 from dynamicprompts.generators.combinatorial import CombinatorialPromptGenerator
 from dynamicprompts.wildcards import WildcardManager
+from dynamicprompts.wildcards.values import WildcardValues
 
 
 class TestCombinatorialGenerator:
@@ -20,8 +21,8 @@ class TestCombinatorialGenerator:
 
         generator = CombinatorialPromptGenerator(wildcard_manager)
 
-        wildcard_manager.get_all_values = Mock(
-            return_value=["bread", "butter", "cheese"],
+        wildcard_manager.get_values = Mock(
+            return_value=WildcardValues.from_items(["bread", "butter", "cheese"]),
         )
         prompts = list(generator.generate(prompt, 10))
 
@@ -72,8 +73,8 @@ class TestCombinatorialGenerator:
 
         generator = CombinatorialPromptGenerator(wildcard_manager)
 
-        wildcard_manager.get_all_values = Mock(
-            return_value=["bread", "butter", "cheese"],
+        wildcard_manager.get_values = Mock(
+            return_value=WildcardValues.from_items(["bread", "butter", "cheese"]),
         )
         prompts = list(generator.generate(prompt, None))
 

--- a/tests/generators/test_jinja.py
+++ b/tests/generators/test_jinja.py
@@ -7,12 +7,11 @@ from dynamicprompts.generators.jinjagenerator import JinjaGenerator
 from dynamicprompts.generators.promptgenerator import GeneratorException
 from dynamicprompts.parser.config import ParserConfig
 from dynamicprompts.wildcards import WildcardManager
+from dynamicprompts.wildcards.values import WildcardValues
 
 pytest.importorskip("jinja2")
 
-GET_ALL_VALUES = (
-    "dynamicprompts.wildcards.wildcard_manager.WildcardManager.get_all_values"
-)
+GET_VALUES = "dynamicprompts.wildcards.wildcard_manager.WildcardManager.get_values"
 
 
 @pytest.fixture
@@ -121,11 +120,19 @@ class TestJinjaGenerator:
         {{% endfor %}}
         """
 
-        with patch(GET_ALL_VALUES) as mock_values:
-            mock_values.side_effect = (
-                ["pink", "yellow", wildcard_manager.to_wildcard("blacks"), "purple"],
-                ["black", "grey"],
-            )
+        with patch(GET_VALUES) as mock_values:
+            mock_values.side_effect = [
+                WildcardValues.from_items(i)
+                for i in (
+                    [
+                        "pink",
+                        "yellow",
+                        wildcard_manager.to_wildcard("blacks"),
+                        "purple",
+                    ],
+                    ["black", "grey"],
+                )
+            ]
 
             assert generator.generate(template) == [
                 "My favourite colour is pink",
@@ -146,12 +153,15 @@ class TestJinjaGenerator:
         {{% endfor %}}
         """
 
-        with patch(GET_ALL_VALUES) as mock_values:
-            mock_values.side_effect = (
-                ["pink", "yellow", wildcard_manager.to_wildcard("black"), "purple"],
-                ["black", wildcard_manager.to_wildcard("greys")],
-                ["light grey", "dark grey"],
-            )
+        with patch(GET_VALUES) as mock_values:
+            mock_values.side_effect = [
+                WildcardValues.from_items(i)
+                for i in (
+                    ["pink", "yellow", wildcard_manager.to_wildcard("black"), "purple"],
+                    ["black", wildcard_manager.to_wildcard("greys")],
+                    ["light grey", "dark grey"],
+                )
+            ]
 
             assert generator.generate(template) == [
                 "My favourite colour is pink",

--- a/tests/generators/test_random.py
+++ b/tests/generators/test_random.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from unittest.mock import patch
 
 import pytest
@@ -69,4 +70,15 @@ class TestRandomGenerator:
             "A red ball",
             "A green ball",
             "A blue ball",
+        ]
+
+    def test_weighted_wildcard(self, generator: RandomPromptGenerator):
+        prompt = "I saw a __weighted-animals/heavy__"
+        prompts = Counter(generator.generate(prompt, 1500))
+        # Over 1500 generations with a non-biased RNG we should always the correct order...
+        assert [s for s, n in prompts.most_common()] == [
+            "I saw a elephant",
+            "I saw a rhino",
+            "I saw a hippo",
+            "I saw a giraffe",
         ]

--- a/tests/samplers/test_prompts.py
+++ b/tests/samplers/test_prompts.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +17,7 @@ from dynamicprompts.samplers import (
 )
 from dynamicprompts.sampling_context import SamplingContext
 from dynamicprompts.wildcards import WildcardManager
+from dynamicprompts.wildcards.values import WildcardValues
 from pytest_lazyfixture import lazy_fixture
 
 from tests.conftest import sampling_context_lazy_fixtures
@@ -32,10 +32,9 @@ from tests.utils import cross, interleave, zipstr
 
 
 @pytest.fixture
-def data_lookups(wildcard_manager: WildcardManager) -> dict[str, list[str]]:
-    wildcard_colours = wildcard_manager.get_all_values("colors*")
-    shuffled_colours = wildcard_colours.copy()
-    random.shuffle(shuffled_colours)
+def data_lookups(wildcard_manager: WildcardManager) -> dict[str, WildcardValues]:
+    wildcard_colours = wildcard_manager.get_values("colors*")
+    shuffled_colours = wildcard_colours.shuffled()
 
     return {
         "wildcard_colours": wildcard_colours,
@@ -460,8 +459,8 @@ class TestPrompts:
 
         with patch.object(
             sampling_context.wildcard_manager,
-            "get_all_values",
-            side_effect=lambda name: RED_GREEN_BLUE,
+            "get_values",
+            return_value=WildcardValues.from_items(RED_GREEN_BLUE),
         ):
             with patch_random_sampler_wildcard_choice(expected):
                 prompts = list(sampling_context.sample_prompts(template, len(expected)))

--- a/tests/samplers/test_utils.py
+++ b/tests/samplers/test_utils.py
@@ -26,7 +26,7 @@ def test_wildcard_to_variant(sampling_context: SamplingContext):
     )
     assert variant_command.min_bound == 1
     assert variant_command.max_bound == len(
-        sampling_context.wildcard_manager.get_all_values("colors*"),
+        sampling_context.wildcard_manager.get_values("colors*"),
     )
     assert variant_command.separator == "-"
     assert variant_command.sampling_method == wildcard_command.sampling_method

--- a/tests/samplers/utils.py
+++ b/tests/samplers/utils.py
@@ -53,8 +53,8 @@ def patch_random_sampler_wildcard_choice(choices: list[str]):
     # Good to go
     return patch.object(
         RandomSampler,
-        "_get_wildcard_choice",
-        side_effect=choices,
+        "_get_wildcard_choice_generator",
+        return_value=iter(choices),
     )
 
 

--- a/tests/test_data/wildcards/weighted.yaml
+++ b/tests/test_data/wildcards/weighted.yaml
@@ -1,0 +1,10 @@
+weighted-animals:
+  heavy:
+    - 50::elephant
+    - 20.5::rhino
+    - 10::hippo
+    - 5::giraffe
+  light:
+    - { weight: 1, text: mouse }
+    - { weight: 2, text: rabbit }
+    - { weight: 3, content: cat }

--- a/tests/test_sd_issues.py
+++ b/tests/test_sd_issues.py
@@ -62,7 +62,7 @@ def test_sd_212(wildcard_manager: WildcardManager):
 def test_sd_307(wildcard_manager: WildcardManager):
     generator = RandomPromptGenerator(wildcard_manager)
     prompts = generator.generate("{2$$__colors-cold__}", 2)
-    colors = wildcard_manager.get_all_values("colors-cold")
+    colors = wildcard_manager.get_values("colors-cold")
     combinations = [f"{c1},{c2}" for c1 in colors for c2 in colors if c1 != c2]
     # check the every prompt is a combination of two colors
     assert all(p in combinations for p in prompts)
@@ -109,9 +109,9 @@ def test_dp_28():
 def test_sd_358(wildcard_manager: WildcardManager):
     generator = RandomPromptGenerator(wildcard_manager)
     prompts = generator.generate("{2$$__referencing-colors__}", 2)
-    colors = wildcard_manager.get_all_values(
+    colors = wildcard_manager.get_values(
         "colors-cold",
-    ) + wildcard_manager.get_all_values("colors-warm")
+    ) + wildcard_manager.get_values("colors-warm")
     combinations = [f"{c1},{c2}" for c1 in colors for c2 in colors if c1 != c2]
     # check the every prompt is a combination of two colors
     assert all(p in combinations for p in prompts)


### PR DESCRIPTION
Refs https://github.com/adieyal/sd-dynamic-prompts/issues/612.

Stacks on https://github.com/adieyal/dynamicprompts/pull/98 since this uses some library features only in Python 3.8+.

This PR looks a bit big, but that's mostly because there was a whole lot of patching going on in tests that needed to be changed, since we now have fancy new `WildcardValues` collection and `WildcardItem` objects.

The TL;DR is we now support weights in JSON and YAML wildcard files with either an object syntax

```yaml
  light:
    - { weight: 1, text: mouse }
    - { weight: 2, text: rabbit }
    - { weight: 3, content: cat }
```
or a shorthand
```yaml
  heavy:
    - 50::elephant
    - 20.5::rhino
    - 10::hippo
    - 5::giraffe
```
The shorthand is _not_ parsed from regular TXT files at this point, because I was afraid it might mess up someone's workflow. Somehow.