### PR TITLE
Have internal sampling APIs return SamplingResults

### DIFF
--- a/src/dynamicprompts/generators/combinatorial.py
+++ b/src/dynamicprompts/generators/combinatorial.py
@@ -27,12 +27,12 @@ class CombinatorialPromptGenerator(PromptGenerator):
             parser_config=parser_config,
         )
 
-    def generate(  # type: ignore[override]
+    def generate(
         self,
         template: str | None,
         max_prompts: int | None = constants.MAX_IMAGES,
         **kwargs,
     ) -> list[str]:
-        return list(
-            self._context.sample_prompts((template or ""), max_prompts),
-        )
+        return [
+            str(p) for p in self._context.sample_prompts((template or ""), max_prompts)
+        ]

--- a/src/dynamicprompts/generators/randomprompt.py
+++ b/src/dynamicprompts/generators/randomprompt.py
@@ -68,7 +68,9 @@ class RandomPromptGenerator(PromptGenerator):
             prompts = []
             for seed in seeds:
                 self._context.rand.seed(seed)
-                prompts.append(next(iter(gen)))
-            return prompts
+                prompts.append(str(next(iter(gen))))
         else:
-            return list(self._context.sample_prompts(template, num_images))
+            prompts = [
+                str(p) for p in self._context.sample_prompts(template, num_images)
+            ]
+        return prompts

--- a/src/dynamicprompts/jinja_extensions.py
+++ b/src/dynamicprompts/jinja_extensions.py
@@ -45,22 +45,22 @@ def wildcard(environment: Environment, wildcard_name: str) -> list[str]:
     wm: WildcardManager = environment.globals["wildcard_manager"]  # type: ignore
     generator: CombinatorialPromptGenerator = environment.globals["generators"]["combinatorial"]  # type: ignore
 
-    return list(generator.generate(wm.to_wildcard(wildcard_name)))
-    return combinatorial_sample(environment, wildcard_name)
+    return [str(r) for r in generator.generate(wm.to_wildcard(wildcard_name))]
 
 
 @pass_environment
 def random_sample(environment: Environment, prompt: str) -> str:
     generator = environment.globals["generators"]["random"]  # type: ignore
 
-    return list(generator.generate(prompt))[0]
+    ps = generator.generate(prompt)
+    return str(next(iter(ps)))
 
 
 @pass_environment
 def combinatorial_sample(environment: Environment, prompt: str) -> list[str]:
     generator = environment.globals["generators"]["combinatorial"]  # type: ignore
 
-    return list(generator.generate(prompt))
+    return [str(p) for p in generator.generate(prompt)]
 
 
 class PromptExtension(Extension):

--- a/src/dynamicprompts/samplers/combinatorial.py
+++ b/src/dynamicprompts/samplers/combinatorial.py
@@ -20,18 +20,9 @@ from dynamicprompts.samplers.utils import (
 )
 from dynamicprompts.sampling_context import SamplingContext
 from dynamicprompts.types import StringGen
+from dynamicprompts.utils import dedupe
 
 logger = logging.getLogger(__name__)
-
-
-def _dedupe(arr: list[str]) -> tuple[str, ...]:
-    seen: set[str] = set()
-    result: list[str] = []
-    for item in arr:
-        if item not in seen:
-            seen.add(item)
-            result.append(item)
-    return tuple(result)
 
 
 def _combo_to_prompt(
@@ -138,7 +129,7 @@ class CombinatorialSampler(Sampler):
             ):
                 for combo in variant_command.get_value_combinations(bound):
                     for prompt_arr in _combo_to_prompt(context, combo):
-                        deduped_arr = _dedupe(prompt_arr)
+                        deduped_arr = dedupe(prompt_arr, key=str)
                         correct_size = len(deduped_arr) == bound
                         if correct_size and deduped_arr not in seen:
                             seen.add(deduped_arr)

--- a/src/dynamicprompts/samplers/command_collection.py
+++ b/src/dynamicprompts/samplers/command_collection.py
@@ -4,7 +4,8 @@ from typing import Iterable
 
 from dynamicprompts.commands import Command
 from dynamicprompts.sampling_context import SamplingContext
-from dynamicprompts.types import CommandList, StringGen
+from dynamicprompts.sampling_result import SamplingResult
+from dynamicprompts.types import CommandList, ResultGen
 
 
 class CommandCollection:
@@ -15,9 +16,9 @@ class CommandCollection:
     def __init__(self, commands: Iterable[Command], context: SamplingContext) -> None:
         self._commands = list(commands)
         self._generators = [context.generator_from_command(c) for c in self._commands]
-        self._values: list[str | None] = [next(g) for g in self._generators]
+        self._values: list[SamplingResult | None] = [next(g) for g in self._generators]
 
-    def get_value(self, command: Command) -> str | None:
+    def get_value(self, command: Command) -> SamplingResult | None:
         try:
             index = self._commands.index(command)
         except ValueError:
@@ -30,7 +31,9 @@ class CommandCollection:
             self._values[index] = next(generator)
         except StopIteration:
             self._values[index] = None
-
+        if self._values[index]:
+            # TODO: remove the following safety assert?
+            assert isinstance(self._values[index], SamplingResult), "oopsy"
         return value
 
     @property
@@ -38,5 +41,5 @@ class CommandCollection:
         return self._commands
 
     @property
-    def generators(self) -> list[StringGen]:
+    def generators(self) -> list[ResultGen]:
         return self._generators

--- a/src/dynamicprompts/samplers/random.py
+++ b/src/dynamicprompts/samplers/random.py
@@ -15,7 +15,8 @@ from dynamicprompts.samplers.utils import (
     wildcard_to_variant,
 )
 from dynamicprompts.sampling_context import SamplingContext
-from dynamicprompts.types import StringGen
+from dynamicprompts.sampling_result import SamplingResult
+from dynamicprompts.types import ResultGen
 from dynamicprompts.utils import choose_without_replacement, rotate_and_join
 from dynamicprompts.wildcards.values import WildcardValues
 
@@ -62,7 +63,7 @@ class RandomSampler(Sampler):
         self,
         command: VariantCommand,
         context: SamplingContext,
-    ) -> StringGen:
+    ) -> ResultGen:
         if len(command.values) == 0:
             return
         elif len(command.values) == 1:
@@ -100,7 +101,7 @@ class RandomSampler(Sampler):
             ]
 
             if len(sub_generators) == 0:
-                yield ""
+                yield SamplingResult(text="")
             else:
                 yield rotate_and_join(
                     sub_generators,
@@ -111,7 +112,7 @@ class RandomSampler(Sampler):
         self,
         command: WildcardCommand,
         context: SamplingContext,
-    ) -> StringGen:
+    ) -> ResultGen:
         context = context.with_variables(command.variables)
         values = context.wildcard_manager.get_values(command.wildcard)
 

--- a/src/dynamicprompts/samplers/utils.py
+++ b/src/dynamicprompts/samplers/utils.py
@@ -5,7 +5,8 @@ import logging
 from dynamicprompts.commands import VariantCommand, VariantOption, WildcardCommand
 from dynamicprompts.parser.parse import parse
 from dynamicprompts.sampling_context import SamplingContext
-from dynamicprompts.types import StringGen
+from dynamicprompts.sampling_result import SamplingResult
+from dynamicprompts.types import ResultGen
 
 logger = logging.getLogger(__name__)
 
@@ -40,11 +41,12 @@ def wildcard_to_variant(
 def get_wildcard_not_found_fallback(
     command: WildcardCommand,
     context: SamplingContext,
-) -> StringGen:
+) -> ResultGen:
     """
     Logs a warning, then infinitely yields the wrapped wildcard.
     """
     logger.warning(f"No values found for wildcard {command.wildcard}")
     wrapped_wildcard = context.wildcard_manager.to_wildcard(command.wildcard)
+    res = SamplingResult(text=wrapped_wildcard)
     while True:
-        yield wrapped_wildcard
+        yield res

--- a/src/dynamicprompts/sampling_result.py
+++ b/src/dynamicprompts/sampling_result.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Iterable
+
+
+@dataclasses.dataclass(frozen=True)
+class SamplingResult:
+    """
+    An internal result of a sampling. May contain metadata in the future.
+    """
+
+    text: str
+
+    def __str__(self):
+        return self.text
+
+    @property
+    def dedupe_key(self) -> tuple[str]:
+        # Used by e.g. combinatorial sampling's fragment deduplication.
+        # Please make sure to update this if you add more fields to SamplingResult.
+        return (self.text,)
+
+    def whitespace_squashed(self) -> SamplingResult:
+        from dynamicprompts.utils import squash_whitespace
+
+        return dataclasses.replace(self, text=squash_whitespace(self.text))
+
+    @classmethod
+    def joined(
+        cls,
+        results: Iterable[SamplingResult],
+        *,
+        separator: str,
+    ) -> SamplingResult:
+        from dynamicprompts.utils import removeprefix, removesuffix
+
+        joined = separator.join(r.text for r in results)
+        if separator:
+            joined = removeprefix(joined, separator)
+            joined = removesuffix(joined, separator)
+        return cls(text=joined)

--- a/src/dynamicprompts/types.py
+++ b/src/dynamicprompts/types.py
@@ -3,12 +3,28 @@ from __future__ import annotations
 from typing import Generator, Iterable, List
 
 from dynamicprompts.commands import Command
+from dynamicprompts.sampling_result import SamplingResult
 
-StringGen = Generator[str, None, None]
+ResultGen = Generator[SamplingResult, None, None]
+ResultIter = Iterable[SamplingResult]
 CommandList = List[Command]
 CommandListGen = Generator[CommandList, None, None]
 StringIter = Iterable[str]
 
 
-def to_string_gen(strs: StringIter) -> StringGen:
-    yield from strs
+def to_result_gen(values: Iterable[SamplingResult | str]) -> ResultGen:
+    for s in values:
+        if isinstance(s, SamplingResult):
+            yield s
+        else:
+            assert isinstance(s, str), f"expected str, got {type(s)}"
+            yield SamplingResult(text=s)
+
+
+def to_string_gen(values: Iterable[SamplingResult | str]) -> StringIter:
+    for s in values:
+        if isinstance(s, SamplingResult):
+            yield s.text
+        else:
+            assert isinstance(s, str), f"expected str, got {type(s)}"
+            yield s

--- a/src/dynamicprompts/utils.py
+++ b/src/dynamicprompts/utils.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import random
-from collections import OrderedDict
 from itertools import cycle
-from typing import Iterable, TypeVar
+from typing import Any, Iterable, TypeVar
 
 from dynamicprompts.types import StringGen
 
@@ -26,9 +25,15 @@ def is_empty_line(line: str | None) -> bool:
     return line is None or line.strip() == "" or line.strip().startswith("#")
 
 
-def dedupe(arr: list[str]) -> tuple[str, ...]:
-    ordered_dict = OrderedDict.fromkeys(arr)
-    return tuple(ordered_dict.keys())
+def dedupe(arr: list[T], key=lambda x: x) -> tuple[T, ...]:
+    seen_keys: set[Any] = set()
+    result: list[T] = []
+    for item in arr:
+        k = key(item)
+        if k not in seen_keys:
+            seen_keys.add(k)
+            result.append(item)
+    return tuple(result)
 
 
 def rotate_all(generators: Iterable[StringGen]) -> list[str]:

--- a/src/dynamicprompts/utils.py
+++ b/src/dynamicprompts/utils.py
@@ -10,11 +10,11 @@ T = TypeVar("T")
 
 
 def removeprefix(s: str, prefix: str) -> str:
-    return s[len(prefix) :] if s.startswith(prefix) else s
+    return s[len(prefix) :] if prefix and s.startswith(prefix) else s
 
 
 def removesuffix(s: str, suffix: str) -> str:
-    return s[: -len(suffix)] if s.endswith(suffix) else s
+    return s[: -len(suffix)] if suffix and s.endswith(suffix) else s
 
 
 def squash_whitespace(s: str) -> str:

--- a/src/dynamicprompts/utils.py
+++ b/src/dynamicprompts/utils.py
@@ -4,7 +4,8 @@ import random
 from itertools import cycle
 from typing import Any, Iterable, TypeVar
 
-from dynamicprompts.types import StringGen
+from dynamicprompts.sampling_result import SamplingResult
+from dynamicprompts.types import ResultGen
 
 T = TypeVar("T")
 
@@ -36,21 +37,21 @@ def dedupe(arr: list[T], key=lambda x: x) -> tuple[T, ...]:
     return tuple(result)
 
 
-def rotate_all(generators: Iterable[StringGen]) -> list[str]:
+def rotate_all(generators: Iterable[ResultGen]) -> list[SamplingResult]:
     return [next(gen) for gen in generators]
 
 
 def rotate_and_join(
-    generators: Iterable[StringGen],
+    generators: Iterable[ResultGen],
     *,
     separator: str,
-) -> str:
-    return separator.join(rotate_all(generators))
+) -> SamplingResult:
+    return SamplingResult.joined(rotate_all(generators), separator=separator)
 
 
 def next_sampler_next_value(
-    samplers: Iterable[StringGen],
-) -> StringGen:
+    samplers: Iterable[ResultGen],
+) -> ResultGen:
     yield from (next(iter(sampler)) for sampler in cycle(samplers))
 
 

--- a/tests/generators/test_combinatorial.py
+++ b/tests/generators/test_combinatorial.py
@@ -12,9 +12,7 @@ class TestCombinatorialGenerator:
         generator = CombinatorialPromptGenerator(wildcard_manager)
 
         prompts = list(generator.generate(prompt, 10))
-
-        assert len(prompts) == 1
-        assert prompts[0] == prompt
+        assert prompts == [prompt]
 
     def test_generate_with_wildcard(self, wildcard_manager: WildcardManager):
         prompt = "I love __food__"
@@ -26,30 +24,32 @@ class TestCombinatorialGenerator:
         )
         prompts = list(generator.generate(prompt, 10))
 
-        assert len(prompts) == 3
-        assert prompts[0] == "I love bread"
-        assert prompts[1] == "I love butter"
-        assert prompts[2] == "I love cheese"
+        assert prompts == [
+            "I love bread",
+            "I love butter",
+            "I love cheese",
+        ]
 
         prompts = list(generator.generate(prompt, 2))
 
-        assert len(prompts) == 2
-        assert prompts[0] == "I love bread"
-        assert prompts[1] == "I love butter"
+        assert prompts == [
+            "I love bread",
+            "I love butter",
+        ]
 
     def test_generate_variant_with_separator(self, wildcard_manager: WildcardManager):
         prompt = "{2$$ and $$A|B|C}"
         generator = CombinatorialPromptGenerator(wildcard_manager)
 
         prompts = list(generator.generate(prompt))
-        assert len(prompts) == 6
-
-        assert prompts[0] == "A and B"
-        assert prompts[1] == "A and C"
-        assert prompts[2] == "B and A"
-        assert prompts[3] == "B and C"
-        assert prompts[4] == "C and A"
-        assert prompts[5] == "C and B"
+        assert prompts == [
+            "A and B",
+            "A and C",
+            "B and A",
+            "B and C",
+            "C and A",
+            "C and B",
+        ]
 
     def test_generate_variant_with_pipe_separator(
         self,
@@ -59,14 +59,14 @@ class TestCombinatorialGenerator:
         generator = CombinatorialPromptGenerator(wildcard_manager)
 
         prompts = list(generator.generate(prompt, 9))
-        assert len(prompts) == 6
-
-        assert prompts[0] == "A|B"
-        assert prompts[1] == "A|C"
-        assert prompts[2] == "B|A"
-        assert prompts[3] == "B|C"
-        assert prompts[4] == "C|A"
-        assert prompts[5] == "C|B"
+        assert prompts == [
+            "A|B",
+            "A|C",
+            "B|A",
+            "B|C",
+            "C|A",
+            "C|B",
+        ]
 
     def test_all_generations(self, wildcard_manager: WildcardManager):
         prompt = "I love __food__ and __drink__"
@@ -76,22 +76,20 @@ class TestCombinatorialGenerator:
         wildcard_manager.get_values = Mock(
             return_value=WildcardValues.from_items(["bread", "butter", "cheese"]),
         )
-        prompts = list(generator.generate(prompt, None))
+        for limit in (None, 9):
+            prompts = list(generator.generate(prompt, limit))
 
-        assert len(prompts) == 9
-        assert prompts[0] == "I love bread and bread"
-        assert prompts[1] == "I love bread and butter"
-        assert prompts[2] == "I love bread and cheese"
-        assert prompts[3] == "I love butter and bread"
-        assert prompts[4] == "I love butter and butter"
-        assert prompts[5] == "I love butter and cheese"
-        assert prompts[6] == "I love cheese and bread"
-        assert prompts[7] == "I love cheese and butter"
-        assert prompts[8] == "I love cheese and cheese"
-
-        prompts = generator.generate(prompt)
-
-        assert len(list(prompts)) == 9
+            assert prompts == [
+                "I love bread and bread",
+                "I love bread and butter",
+                "I love bread and cheese",
+                "I love butter and bread",
+                "I love butter and butter",
+                "I love butter and cheese",
+                "I love cheese and bread",
+                "I love cheese and butter",
+                "I love cheese and cheese",
+            ]
 
     def test_without_wildcard_manager(self):
         generator = CombinatorialPromptGenerator()

--- a/tests/generators/test_feelinglucky.py
+++ b/tests/generators/test_feelinglucky.py
@@ -34,10 +34,8 @@ def test_default_generator():
 
 def test_generate(mock_generator, mock_requests, mock_random):
     generator = FeelingLuckyGenerator(mock_generator)
-    prompts = generator.generate("This is a test", 1)
-
-    assert len(prompts) == 1
-    assert prompts[0] == "ABC"
+    prompts = list(generator.generate("This is a test", 1))
+    assert prompts == ["ABC"]
 
     mock_generator.generate.assert_called_with("This is a test", 1)
     mock_random.choices.assert_called_with([{"prompt": "ABC"}, {"prompt": "XYZ"}], k=1)
@@ -47,10 +45,8 @@ def test_generate_accepts_kwargs(mock_generator, mock_requests, mock_random):
     generator = FeelingLuckyGenerator(mock_generator)
 
     # Call generate with an arbitrary keyword argument
-    prompts = generator.generate("This is a test", 1, some_kwarg="value")
-
-    assert len(prompts) == 1
-    assert prompts[0] == "ABC"
+    prompts = list(generator.generate("This is a test", 1, some_kwarg="value"))
+    assert prompts == ["ABC"]
 
     # Check that the generate method of the underlying generator was called with the keyword argument
     mock_generator.generate.assert_called_with("This is a test", 1, some_kwarg="value")

--- a/tests/generators/test_random.py
+++ b/tests/generators/test_random.py
@@ -29,7 +29,7 @@ class TestRandomGenerator:
         with patch_random_sampler_wildcard_choice(animals):
             prompts = list(generator.generate(prompt, 4))
 
-        assert prompts == [f"I saw a {animal}" for animal in animals]
+        assert [str(p) for p in prompts] == [f"I saw a {animal}" for animal in animals]
 
     def test_without_wildcard_manager(self):
         generator = RandomPromptGenerator()
@@ -66,7 +66,7 @@ class TestRandomGenerator:
     def test_cyclical_sampler_with_seeds(self, generator: RandomPromptGenerator):
         template = "A {@red|green|blue} ball"
         prompts = generator.generate(template=template, num_images=3, seeds=[1, 2, 3])
-        assert prompts == [
+        assert [str(p) for p in prompts] == [
             "A red ball",
             "A green ball",
             "A blue ball",

--- a/tests/samplers/test_command_collection.py
+++ b/tests/samplers/test_command_collection.py
@@ -31,19 +31,17 @@ class TestCommandCollection:
         assert collection.commands[2].literal == "c"
 
         for command, generator in zip(commands, collection.generators):
-            assert next(generator) == command.literal
+            assert str(next(generator)) == command.literal
 
         generator = collection.generators[0]
-        assert next(generator) == "a"
-        assert next(generator) == "a"
-        assert next(generator) == "a"
-        assert next(generator) == "a"
+        for x in range(4):
+            assert str(next(generator)) == "a"
 
     def test_generators_values(self, commands, combinatorial_sampling_context):
         collection = CommandCollection(commands, combinatorial_sampling_context)
 
         for command in commands:
-            assert collection.get_value(command) == command.literal
+            assert str(collection.get_value(command)) == command.literal
 
     def test_generators_for_missing_command(
         self,
@@ -70,5 +68,5 @@ class TestCommandCollection:
             combinatorial_sampling_context,
         )
 
-        assert collection.get_value(combinatorial_command) == "combinatorial"
+        assert str(collection.get_value(combinatorial_command)) == "combinatorial"
         assert collection.get_value(combinatorial_command) is None

--- a/tests/samplers/test_command_collection.py
+++ b/tests/samplers/test_command_collection.py
@@ -23,12 +23,8 @@ class TestCommandCollection:
         random_sampling_context,
     ):
         collection = CommandCollection(commands, context=random_sampling_context)
-        assert len(collection.commands) == 3
         assert len(collection.generators) == 3
-
-        assert collection.commands[0].literal == "a"
-        assert collection.commands[1].literal == "b"
-        assert collection.commands[2].literal == "c"
+        assert [c.literal for c in collection.commands] == ["a", "b", "c"]
 
         for command, generator in zip(commands, collection.generators):
             assert str(next(generator)) == command.literal

--- a/tests/samplers/test_common.py
+++ b/tests/samplers/test_common.py
@@ -55,7 +55,7 @@ class TestSequenceCommand:
     def test_prompts(self, sampling_context: SamplingContext):
         sequence = SequenceCommand.from_literals(["one", " ", "two", " ", "three"])
         prompt = next(sampling_context.generator_from_command(sequence))
-        assert prompt == "one two three"
+        assert str(prompt) == "one two three"
 
     @pytest.mark.parametrize("sampling_context", sampling_context_lazy_fixtures)
     def test_custom_separator(self, sampling_context: SamplingContext):
@@ -63,7 +63,7 @@ class TestSequenceCommand:
         command2 = LiteralCommand("sentence")
         sequence = SequenceCommand([command1, command2], separator="|")
         prompt = next(sampling_context.generator_from_command(sequence))
-        assert prompt == "A|sentence"
+        assert str(prompt) == "A|sentence"
 
 
 class TestLiteralCommand:
@@ -71,7 +71,7 @@ class TestLiteralCommand:
     def test_single_literal(self, sampling_context: SamplingContext):
         literal = LiteralCommand("one")
         gen = sampling_context.generator_from_command(literal)
-        assert next(gen) == "one"
+        assert str(next(gen)) == "one"
 
     @pytest.mark.parametrize("sampling_context", sampling_context_lazy_fixtures)
     def test_multiple_literals(
@@ -81,7 +81,7 @@ class TestLiteralCommand:
         sequence = SequenceCommand.from_literals(["one", " ", "two", " ", "three"])
         prompts = sampling_context.generator_from_command(sequence)
 
-        assert next(prompts) == "one two three"
+        assert str(next(prompts)) == "one two three"
 
 
 class TestVariantCommand:
@@ -96,7 +96,7 @@ class TestVariantCommand:
         command = VariantCommand.from_literals_and_weights(["one"])
 
         gen = sampling_context.generator_from_command(command)
-        assert next(gen) == "one"
+        assert str(next(gen)) == "one"
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -127,7 +127,7 @@ class TestVariantCommand:
             prompts = [next(gen) for _ in expected]
 
         for prompt, e in zip(prompts, expected):
-            assert prompt == e
+            assert str(prompt) == e
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -162,7 +162,7 @@ class TestVariantCommand:
             prompts = [next(gen) for _ in expected]
 
         for prompt, e in zip(prompts, expected):
-            assert prompt == f"{e} circles"
+            assert str(prompt) == f"{e} circles"
 
     @pytest.mark.parametrize("sampling_context", sampling_context_lazy_fixtures)
     def test_variant_with_zero_bound(
@@ -176,7 +176,7 @@ class TestVariantCommand:
         )
 
         gen = sampling_context.generator_from_command(command1)
-        assert next(gen) == ""
+        assert str(next(gen)) == ""
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -220,7 +220,7 @@ class TestVariantCommand:
             prompts = [next(gen) for _ in expected]
 
         for prompt, e in zip(prompts, expected):
-            assert prompt == e
+            assert str(prompt) == e
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -265,7 +265,7 @@ class TestVariantCommand:
             prompts = [next(gen) for _ in expected]
 
         for prompt, e in zip(prompts, expected):
-            assert prompt == e
+            assert str(prompt) == e
 
     @pytest.mark.parametrize("separator", [",", " and "])
     @pytest.mark.parametrize(
@@ -312,7 +312,7 @@ class TestVariantCommand:
         color_pair_strings = [
             f"{c1.literal}{separator}{c2.literal}" for c1, c2 in color_pairs
         ]
-        assert prompts == color_pair_strings
+        assert [str(p) for p in prompts] == color_pair_strings
 
     @pytest.mark.parametrize(
         ("sampling_context", "key"),
@@ -354,7 +354,7 @@ class TestVariantCommand:
         color_pair_strings = [
             f"{c1.literal}{separator}{c2.literal}" for c1, c2 in color_pairs
         ]
-        assert prompts == color_pair_strings
+        assert [str(p) for p in prompts] == color_pair_strings
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -397,7 +397,7 @@ class TestVariantCommand:
             prompts = [next(gen) for _ in expected]
 
         for prompt, e in zip(prompts, expected):
-            assert prompt == e
+            assert str(prompt) == e
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -449,7 +449,7 @@ class TestVariantCommand:
             prompts = [next(gen) for _ in expected]
 
         for prompt, e in zip(prompts, expected):
-            assert prompt == f"{e} are cool"
+            assert str(prompt) == f"{e} are cool"
 
 
 class TestWildcardsCommand:
@@ -476,7 +476,7 @@ class TestWildcardsCommand:
             prompts = [next(gen) for _ in range(len(values))]
 
         for prompt, e in zip(prompts, values):
-            assert prompt == e
+            assert str(prompt) == e
 
     @pytest.mark.parametrize(
         ("sampling_context", "key"),
@@ -502,8 +502,9 @@ class TestWildcardsCommand:
         with patch_random_sampler_wildcard_choice(values):
             prompts = [next(gen) for _ in range(len(values))]
 
-        for prompt, e in zip(prompts, values):
-            assert prompt == f"{e} are cool"
+        with patch_random_sampler_wildcard_choice(values):
+            for prompt, e in zip(prompts, values):
+                assert str(prompt) == f"{e} are cool"
 
     @pytest.mark.parametrize(
         ("sampling_context", "key"),
@@ -555,7 +556,7 @@ class TestWildcardsCommand:
             raise ValueError("Invalid sampler")
 
         for prompt, e in zip(prompts, expected):
-            assert prompt == e
+            assert str(prompt) == e
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -588,7 +589,7 @@ class TestWildcardsCommand:
 
             prompts = [next(gen) for _ in range(len(expected))]
 
-            assert prompts == expected
+            assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -622,19 +623,26 @@ class TestWildcardsCommand:
         wildcard_command = WildcardCommand("referencing-colors")
         sequence = SequenceCommand([wildcard_command])
         gen = sampling_context.generator_from_command(sequence)
-        assert list(islice(gen, len(expected))) == expected
+        ps = [str(p) for p in islice(gen, len(expected))]
+        assert ps == expected
 
 
 class TestVariableCommands:
     @pytest.mark.parametrize("sampling_context", sampling_context_lazy_fixtures)
     def test_variable_commands(self, sampling_context: SamplingContext):
         cmd = parse("${animal=cat}the animal is ${animal:dog}")
-        assert next(sampling_context.generator_from_command(cmd)) == "the animal is cat"
+        assert (
+            str(next(sampling_context.generator_from_command(cmd)))
+            == "the animal is cat"
+        )
 
     @pytest.mark.parametrize("sampling_context", sampling_context_lazy_fixtures)
     def test_variable_commands_default(self, sampling_context: SamplingContext):
         cmd = parse("the animal is ${animal:dog}")
-        assert next(sampling_context.generator_from_command(cmd)) == "the animal is dog"
+        assert (
+            str(next(sampling_context.generator_from_command(cmd)))
+            == "the animal is dog"
+        )
 
     @pytest.mark.parametrize("immediate", [True, False])
     def test_immediate_variable_commands(
@@ -660,7 +668,7 @@ class TestVariableCommands:
     def test_immediate_literal_variable(self, random_sampling_context: SamplingContext):
         # Just a coverage test for the optimization for literal variables
         cmd = parse("${a =! foo}${a}")
-        assert next(random_sampling_context.generator_from_command(cmd)) == "foo"
+        assert str(next(random_sampling_context.generator_from_command(cmd))) == "foo"
 
     def test_unknown_variable(self, wildcard_manager: WildcardManager):
         ctx1 = SamplingContext(
@@ -680,5 +688,5 @@ class TestVariableCommands:
         cmd = parse("${a}")
         with pytest.raises(KeyError):
             next(ctx1.generator_from_command(cmd))
-        assert next(ctx2.generator_from_command(cmd)) == "oop!"
-        assert next(ctx3.generator_from_command(cmd)) == "bloop!"
+        assert str(next(ctx2.generator_from_command(cmd))) == "oop!"
+        assert str(next(ctx3.generator_from_command(cmd))) == "bloop!"

--- a/tests/samplers/test_mixed_methods.py
+++ b/tests/samplers/test_mixed_methods.py
@@ -35,7 +35,7 @@ class TestCombinatorialParent:
     ):
         with patch_random_sampler_variant_choices_with_literals(choices_side_effect):
             prompts = list(combinatorial_sampling_context.sample_prompts(template, 3))
-        assert prompts == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("template", "choices_side_effect", "expected"),
@@ -61,7 +61,7 @@ class TestCombinatorialParent:
     ):
         with patch_random_sampler_variant_choices_with_literals(choices_side_effect):
             prompts = list(combinatorial_sampling_context.sample_prompts(template, 3))
-        assert prompts == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("template", "choices_side_effect", "expected"),
@@ -87,7 +87,7 @@ class TestCombinatorialParent:
     ):
         with patch_random_sampler_variant_choices_with_literals(choices_side_effect):
             prompts = list(combinatorial_sampling_context.sample_prompts(template, 3))
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("template", "choices_side_effect", "expected"),
@@ -121,7 +121,7 @@ class TestCombinatorialParent:
     ):
         with patch_random_sampler_variant_choices_with_literals(choices_side_effect):
             prompts = list(combinatorial_sampling_context.sample_prompts(template, 3))
-        assert prompts == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("template", "choices_side_effect", "expected"),
@@ -147,7 +147,7 @@ class TestCombinatorialParent:
     ):
         with patch_random_sampler_variant_choices_with_literals(choices_side_effect):
             prompts = list(combinatorial_sampling_context.sample_prompts(template, 10))
-        assert prompts == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("sampling_method", "template", "expected"),
@@ -209,7 +209,7 @@ class TestCombinatorialParent:
         ):
             prompts = list(prompts)
 
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("template", "choice_value", "expected"),
@@ -230,7 +230,7 @@ class TestCombinatorialParent:
             with patch_random_sampler_wildcard_choice([choice_value] * 3):
                 prompts = list(prompts)
 
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("template", "choice_side_effect", "expected"),
@@ -260,7 +260,7 @@ class TestCombinatorialParent:
             with patch_random_sampler_wildcard_choice(choice_side_effect):
                 prompts = list(prompts)
 
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
 
 class TestRandomParent:
@@ -284,7 +284,7 @@ class TestRandomParent:
     ):
         with patch_random_sampler_variant_choices_with_literals(choices_side_effect):
             prompts = list(random_sampling_context.sample_prompts(template, 3))
-        assert prompts == expected
+        assert [str(p) for p in prompts] == expected
 
 
 class TestCyclicalParent:
@@ -308,4 +308,4 @@ class TestCyclicalParent:
     ):
         with patch_random_sampler_variant_choices_with_literals(choices_side_effect):
             prompts = list(cyclical_sampling_context.sample_prompts(template, 3))
-        assert prompts == expected
+        assert [str(p) for p in prompts] == expected

--- a/tests/samplers/test_prompts.py
+++ b/tests/samplers/test_prompts.py
@@ -46,7 +46,7 @@ class TestPrompts:
     @pytest.mark.parametrize("sampling_context", sampling_context_lazy_fixtures)
     def test_empty(self, sampling_context: SamplingContext):
         prompts = list(sampling_context.sample_prompts("", 5))
-        assert prompts == []
+        assert [str(p) for p in prompts] == []
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -62,7 +62,9 @@ class TestPrompts:
         expected: list[str],
     ):
         template = "A literal sentence"
-        assert list(sampling_context.sample_prompts(template, 5)) == expected
+        assert [
+            str(p) for p in sampling_context.sample_prompts(template, 5)
+        ] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -78,7 +80,9 @@ class TestPrompts:
         expected: list[str],
     ):
         template = "Test [low emphasis]"
-        assert list(sampling_context.sample_prompts(template, 5)) == expected
+        assert [
+            str(p) for p in sampling_context.sample_prompts(template, 5)
+        ] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -105,7 +109,7 @@ class TestPrompts:
             prompts = list(sampling_context.sample_prompts(template, 5))
 
         for prompt, e in zip(prompts, expected):
-            assert prompt == f"A red {e}"
+            assert str(prompt) == f"A red {e}"
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -139,7 +143,7 @@ class TestPrompts:
 
         expected_sentences = [f"A {e} rose" for e in expected]
 
-        assert list(prompts) == expected_sentences
+        assert [str(p) for p in prompts] == expected_sentences
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -193,7 +197,7 @@ class TestPrompts:
         else:
             prompts = sampling_context.sample_prompts(template, 5)
 
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -256,7 +260,7 @@ class TestPrompts:
         else:
             prompts = sampling_context.sample_prompts(template, 5)
 
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -316,7 +320,7 @@ class TestPrompts:
         else:
             prompts = sampling_context.sample_prompts(template, 5)
 
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -364,7 +368,7 @@ class TestPrompts:
 
         expected = [f"A {e} square" for e in expected]
 
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -391,7 +395,7 @@ class TestPrompts:
 
         expected = [f"A {e} square" for e in expected]
 
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -437,7 +441,7 @@ class TestPrompts:
         else:
             prompts = sampling_context.sample_prompts(template, len(expected))
 
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -466,7 +470,7 @@ class TestPrompts:
                 prompts = list(sampling_context.sample_prompts(template, len(expected)))
             expected = [f"A {e} square" for e in expected]
 
-            assert list(prompts) == expected
+            assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context", "expected"),
@@ -487,7 +491,7 @@ class TestPrompts:
             len(expected),
         )
 
-        assert list(prompts) == [ex.replace("__", wrap) for ex in expected]
+        assert [str(p) for p in prompts] == [ex.replace("__", wrap) for ex in expected]
 
     @pytest.mark.parametrize(
         ("sampling_context", "key"),
@@ -509,7 +513,7 @@ class TestPrompts:
         with patch_random_sampler_variant_choices(expected):
             prompts = list(sampling_context.sample_prompts(template, len(expected)))
 
-        assert list(prompts) == [v[0].literal for v in expected]
+        assert [str(p) for p in prompts] == [v[0].literal for v in expected]
 
     @pytest.mark.parametrize(
         ("sampling_context", "key"),
@@ -556,7 +560,7 @@ class TestPrompts:
 
             prompts = sampling_context.sample_prompts(template, len(expected))
 
-        assert list(prompts) == expected
+        assert [str(p) for p in prompts] == expected
 
     @pytest.mark.parametrize(
         ("sampling_context"),
@@ -572,9 +576,9 @@ class TestPrompts:
     ):
         template = "A red {3$$square|circle}"
         prompts = sampling_context.sample_prompts(template, 10)
-
+        expected = ("A red square,circle", "A red circle,square")
         for el in prompts:
-            assert el in ["A red square,circle", "A red circle,square"]
+            assert str(el) in expected
 
     @pytest.mark.parametrize(
         ("sampling_context"),
@@ -590,7 +594,7 @@ class TestPrompts:
     ):
         template = "(__colors*__:2.3) "
 
-        prompts = list(sampling_context.sample_prompts(template, 20))
+        prompts = [str(p) for p in sampling_context.sample_prompts(template, 20)]
 
         for prompt in prompts:
             assert "( " not in prompt

--- a/tests/test_sd_issues.py
+++ b/tests/test_sd_issues.py
@@ -90,20 +90,17 @@ def test_dp_28():
     prompts = generator.generate(s, 10)
 
     assert len(prompts) == 10
-    assert all(
-        p
-        in [
-            "A",
-            "B",
-            "X and Y",
-            "X and Z",
-            "Y and X",
-            "Y and Z",
-            "Z and X",
-            "Z and Y",
-        ]
-        for p in prompts
-    )
+    expected = {
+        "A",
+        "B",
+        "X and Y",
+        "X and Z",
+        "Y and X",
+        "Y and Z",
+        "Z and X",
+        "Z and Y",
+    }
+    assert all(str(p) in expected for p in prompts)
 
 
 def test_sd_358(wildcard_manager: WildcardManager):
@@ -114,7 +111,7 @@ def test_sd_358(wildcard_manager: WildcardManager):
     ) + wildcard_manager.get_values("colors-warm")
     combinations = [f"{c1},{c2}" for c1 in colors for c2 in colors if c1 != c2]
     # check the every prompt is a combination of two colors
-    assert all(p in combinations for p in prompts)
+    assert all(str(p) in combinations for p in prompts)
 
 
 def test_sd_377(wildcard_manager: WildcardManager, caplog):

--- a/tests/test_variable_features.py
+++ b/tests/test_variable_features.py
@@ -21,7 +21,7 @@ def test_discussion_61(wildcard_manager: WildcardManager):
     seen = set()
     expected = {"fox", "manatee"}
     for prompt in islice(gen, 10):
-        prompt = prompt.strip().lower()
+        prompt = str(prompt).strip().lower()
         assert prompt.startswith("cute kawaii squishy")
         for ex in expected:
             if ex in prompt:
@@ -37,5 +37,5 @@ def test_discussion_61_shorthand(wildcard_manager: WildcardManager):
         default_sampling_method=SamplingMethod.RANDOM,
         wildcard_manager=wildcard_manager,
     )
-    prompt = next(scon.sample_prompts(cmd))
+    prompt = str(next(scon.sample_prompts(cmd)))
     assert prompt.strip().lower().startswith("cute kawaii squishy fox")


### PR DESCRIPTION
This will allow for additional metadata to be gathered during sampling (e.g. wildcard files used, and other future magic).


