### PR TITLE
Don't emit warnings for each actually supported text YAML wildcard

### DIFF
--- a/src/dynamicprompts/wildcards/collection/structured.py
+++ b/src/dynamicprompts/wildcards/collection/structured.py
@@ -33,6 +33,7 @@ def _parse_structured_file_list(value: list[Any]) -> Iterable[str | WildcardItem
                     # fall through to yielding the item as-is.
                     pass
             yield item
+            continue
         elif isinstance(item, dict):
             # Support {"text": "foo", "weight": 1.1} syntax
             #     and {"content": "foo", "weight": 1.1}

--- a/tests/wildcard/test_utils.py
+++ b/tests/wildcard/test_utils.py
@@ -1,0 +1,6 @@
+from dynamicprompts.wildcards.collection.structured import _parse_structured_file_list
+
+
+def test_structured_parsing_emits_no_warnings(caplog):
+    assert list(_parse_structured_file_list(["a", "b", "c"])) == ["a", "b", "c"]
+    assert not caplog.records


### PR DESCRIPTION
Silly bug introduced in #103...