### PR TITLE
Parse single strings as collections of one item in structured wildcard files

### DIFF
--- a/src/dynamicprompts/wildcards/collection/structured.py
+++ b/src/dynamicprompts/wildcards/collection/structured.py
@@ -66,6 +66,11 @@ def _parse_structured_file_dict(
 
         prefix_and_name = (*prefix, name)
         name = "/".join(prefix_and_name)
+
+        if isinstance(value, str):
+            # Parse a single string as a list of one item.
+            value = [value]
+
         if isinstance(value, list):
             try:
                 entries = list(_parse_structured_file_list(value))

--- a/src/dynamicprompts/wildcards/collection/structured.py
+++ b/src/dynamicprompts/wildcards/collection/structured.py
@@ -60,6 +60,10 @@ def _parse_structured_file_dict(
     for name, value in data.items():
         if not isinstance(name, str):
             continue
+
+        if not value:
+            continue
+
         prefix_and_name = (*prefix, name)
         name = "/".join(prefix_and_name)
         if isinstance(value, list):

--- a/tests/test_data/wildcards/pantry.yaml
+++ b/tests/test_data/wildcards/pantry.yaml
@@ -11,6 +11,7 @@ artists:
     - Piet Mondrian
     - Rembrandt van Rijn
     - Vincent van Gogh
+  moonbase: john madden  # interpreted as a single john madden
   1234: 5678  # this is ignored
   flurp: 12345  # this too
   flem: ""  # and this

--- a/tests/test_data/wildcards/pantry.yaml
+++ b/tests/test_data/wildcards/pantry.yaml
@@ -13,3 +13,4 @@ artists:
     - Vincent van Gogh
   1234: 5678  # this is ignored
   flurp: 12345  # this too
+  flem: ""  # and this

--- a/tests/wildcard/test_wildcardmanager.py
+++ b/tests/wildcard/test_wildcardmanager.py
@@ -132,6 +132,7 @@ def test_hierarchy(wildcard_manager: WildcardManager):
         "animals/reptiles/snakes",
         "artists/dutch",
         "artists/finnish",
+        "artists/moonbase",
         "cars/ford/colors",
         "cars/ford/name",
         "cars/ford/types",
@@ -192,8 +193,9 @@ def test_hierarchy(wildcard_manager: WildcardManager):
         "bitter",  # from .json
     }
     assert set(root.child_nodes["artists"].collections) == {
-        "finnish",  # from root pantry YAML's nested dict
         "dutch",  # from root pantry YAML's nested dict
+        "finnish",  # from root pantry YAML's nested dict
+        "moonbase",  # from root pantry YAML's nested dict
     }
 
 
@@ -389,3 +391,9 @@ def test_weight_parsing(wildcard_manager: WildcardManager):
     assert name_to_entry["cat"].weight == 3
     assert name_to_entry["elephant"].weight == 50
     assert name_to_entry["rhino"].weight == 20.5
+
+
+def test_single_string_in_structured_parsed_as_list(wildcard_manager: WildcardManager):
+    assert wildcard_manager.get_values("artists/moonbase").string_values == [
+        "john madden",
+    ]


### PR DESCRIPTION
This makes it a little easier to create collections of named wrappers (#102).