### PR TITLE
(feat) Dynamic Wildcards

### DIFF
--- a/src/dynamicprompts/commands/wildcard_command.py
+++ b/src/dynamicprompts/commands/wildcard_command.py
@@ -8,10 +8,10 @@ from dynamicprompts.enums import SamplingMethod
 
 @dataclasses.dataclass(frozen=True)
 class WildcardCommand(Command):
-    wildcard: str
+    wildcard: Command | str
     sampling_method: SamplingMethod | None = None
     variables: dict[str, Command] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
-        if not isinstance(self.wildcard, str):
-            raise TypeError(f"Wildcard must be a string, not {type(self.wildcard)}")
+        if not isinstance(self.wildcard, (Command, str)):
+            raise TypeError(f"Wildcard must be a Command or str, not {type(self.wildcard)}")

--- a/src/dynamicprompts/commands/wildcard_command.py
+++ b/src/dynamicprompts/commands/wildcard_command.py
@@ -14,4 +14,6 @@ class WildcardCommand(Command):
 
     def __post_init__(self):
         if not isinstance(self.wildcard, (Command, str)):
-            raise TypeError(f"Wildcard must be a Command or str, not {type(self.wildcard)}")
+            raise TypeError(
+                f"Wildcard must be a Command or str, not {type(self.wildcard)}",
+            )

--- a/src/dynamicprompts/parser/parse.py
+++ b/src/dynamicprompts/parser/parse.py
@@ -369,7 +369,7 @@ def _parse_wildcard_variable_access_command(
     parts = parse_result[0].as_dict()    
     name = parts["name"]
     default = parts.get("default") or LiteralCommand(name)
-    return VariableAccessCommand(name=name, default=default)
+    return VariableAccessCommand(name=name, default=LiteralCommand(default.literal.strip()))
 
 def _parse_variable_assignment_command(
     parse_result: pp.ParseResults,

--- a/src/dynamicprompts/parser/parse.py
+++ b/src/dynamicprompts/parser/parse.py
@@ -458,7 +458,7 @@ def create_parser(
         parser_config=parser_config,
         prompt=variant_prompt,
     )
-    wildcard = _configure_wildcard(        
+    wildcard = _configure_wildcard(
         parser_config=parser_config,
         prompt=wildcard_prompt,
     )

--- a/src/dynamicprompts/samplers/combinatorial.py
+++ b/src/dynamicprompts/samplers/combinatorial.py
@@ -142,8 +142,10 @@ class CombinatorialSampler(Sampler):
         context: SamplingContext,
     ) -> ResultGen:
         # TODO: doesn't support weights
+        wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text
         context = context.with_variables(command.variables)
-        values = context.wildcard_manager.get_values(command.wildcard)
+        values = context.wildcard_manager.get_values(wildcard_path)
+        
         if not values:
             yield from get_wildcard_not_found_fallback(command, context)
             return

--- a/src/dynamicprompts/samplers/combinatorial.py
+++ b/src/dynamicprompts/samplers/combinatorial.py
@@ -145,7 +145,7 @@ class CombinatorialSampler(Sampler):
         wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text
         context = context.with_variables(command.variables)
         values = context.wildcard_manager.get_values(wildcard_path)
-        
+
         if not values:
             yield from get_wildcard_not_found_fallback(command, context)
             return

--- a/src/dynamicprompts/samplers/combinatorial.py
+++ b/src/dynamicprompts/samplers/combinatorial.py
@@ -143,7 +143,7 @@ class CombinatorialSampler(Sampler):
         context: SamplingContext,
     ) -> ResultGen:
         # TODO: doesn't support weights
-        wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text
+        wildcard_path = next(iter(context.sample_prompts(command.wildcard, 1))).text
         context = context.with_variables(command.variables)
         values = context.wildcard_manager.get_values(wildcard_path)
 

--- a/src/dynamicprompts/samplers/cycle.py
+++ b/src/dynamicprompts/samplers/cycle.py
@@ -100,7 +100,8 @@ class CyclicalSampler(Sampler):
         context: SamplingContext,
     ) -> ResultGen:
         # TODO: doesn't support weights
-        wc_values = context.wildcard_manager.get_values(command.wildcard)
+        wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text        
+        wc_values = context.wildcard_manager.get_values(wildcard_path)        
         new_context = context.with_variables(
             command.variables,
         ).with_sampling_method(SamplingMethod.CYCLICAL)

--- a/src/dynamicprompts/samplers/cycle.py
+++ b/src/dynamicprompts/samplers/cycle.py
@@ -100,7 +100,7 @@ class CyclicalSampler(Sampler):
         context: SamplingContext,
     ) -> ResultGen:
         # TODO: doesn't support weights
-        wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text
+        wildcard_path = next(iter(context.sample_prompts(command.wildcard, 1))).text
         wc_values = context.wildcard_manager.get_values(wildcard_path)
         new_context = context.with_variables(
             command.variables,

--- a/src/dynamicprompts/samplers/cycle.py
+++ b/src/dynamicprompts/samplers/cycle.py
@@ -12,7 +12,7 @@ from dynamicprompts.commands import (
 )
 from dynamicprompts.samplers.base import Sampler
 from dynamicprompts.samplers.utils import (
-    get_wildcard_not_found_fallback,    
+    get_wildcard_not_found_fallback,
     wildcard_to_variant,
 )
 from dynamicprompts.sampling_context import SamplingContext

--- a/src/dynamicprompts/samplers/cycle.py
+++ b/src/dynamicprompts/samplers/cycle.py
@@ -100,8 +100,8 @@ class CyclicalSampler(Sampler):
         context: SamplingContext,
     ) -> ResultGen:
         # TODO: doesn't support weights
-        wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text        
-        wc_values = context.wildcard_manager.get_values(wildcard_path)        
+        wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text
+        wc_values = context.wildcard_manager.get_values(wildcard_path)
         new_context = context.with_variables(
             command.variables,
         ).with_sampling_method(SamplingMethod.CYCLICAL)

--- a/src/dynamicprompts/samplers/random.py
+++ b/src/dynamicprompts/samplers/random.py
@@ -114,7 +114,7 @@ class RandomSampler(Sampler):
         command: WildcardCommand,
         context: SamplingContext,
     ) -> ResultGen:
-        wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text
+        wildcard_path = next(iter(context.sample_prompts(command.wildcard, 1))).text
         context = context.with_variables(command.variables)
         values = context.wildcard_manager.get_values(wildcard_path)
 

--- a/src/dynamicprompts/samplers/random.py
+++ b/src/dynamicprompts/samplers/random.py
@@ -112,7 +112,7 @@ class RandomSampler(Sampler):
         self,
         command: WildcardCommand,
         context: SamplingContext,
-    ) -> ResultGen:
+    ) -> ResultGen:        
         wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text
         context = context.with_variables(command.variables)
         values = context.wildcard_manager.get_values(wildcard_path)

--- a/src/dynamicprompts/samplers/random.py
+++ b/src/dynamicprompts/samplers/random.py
@@ -112,7 +112,7 @@ class RandomSampler(Sampler):
         self,
         command: WildcardCommand,
         context: SamplingContext,
-    ) -> ResultGen:        
+    ) -> ResultGen:
         wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text
         context = context.with_variables(command.variables)
         values = context.wildcard_manager.get_values(wildcard_path)

--- a/src/dynamicprompts/samplers/random.py
+++ b/src/dynamicprompts/samplers/random.py
@@ -113,8 +113,9 @@ class RandomSampler(Sampler):
         command: WildcardCommand,
         context: SamplingContext,
     ) -> ResultGen:
+        wildcard_path = next(context.sample_prompts(command.wildcard, 1)).text
         context = context.with_variables(command.variables)
-        values = context.wildcard_manager.get_values(command.wildcard)
+        values = context.wildcard_manager.get_values(wildcard_path)
 
         if len(values) == 0:
             yield from get_wildcard_not_found_fallback(command, context)

--- a/src/dynamicprompts/samplers/utils.py
+++ b/src/dynamicprompts/samplers/utils.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import logging
-from functools import partial
-
-import pyparsing as pp
 
 from dynamicprompts.commands import (
     Command,

--- a/src/dynamicprompts/samplers/utils.py
+++ b/src/dynamicprompts/samplers/utils.py
@@ -24,7 +24,7 @@ def wildcard_to_variant(
     max_bound=1,
     separator=",",
 ) -> VariantCommand:
-    wildcard = next(context.sample_prompts(command.wildcard, 1)).text
+    wildcard = next(iter(context.sample_prompts(command.wildcard, 1))).text
     values = context.wildcard_manager.get_values(wildcard)
     min_bound = min(min_bound, len(values))
     max_bound = min(max_bound, len(values))
@@ -51,9 +51,10 @@ def get_wildcard_not_found_fallback(
     """
     Logs a warning, then infinitely yields the wrapped wildcard.
     """
-    wildcard = command.wildcard
-    if isinstance(wildcard, Command):
-        wildcard = next(context.sample_prompts(wildcard, 1)).text
+    if isinstance(command.wildcard, Command):
+        wildcard = next(iter(context.sample_prompts(command.wildcard, 1))).text
+    else:
+        wildcard = str(command.wildcard)
     logger.warning(f"No values found for wildcard {wildcard}")
     wrapped_wildcard = context.wildcard_manager.to_wildcard(wildcard)
     res = SamplingResult(text=wrapped_wildcard)

--- a/src/dynamicprompts/samplers/utils.py
+++ b/src/dynamicprompts/samplers/utils.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import logging
 
-from dynamicprompts.commands import Command, VariantCommand, VariantOption, WildcardCommand
+from dynamicprompts.commands import (
+    Command,
+    VariantCommand,
+    VariantOption,
+    WildcardCommand,
+)
 from dynamicprompts.parser.parse import parse
 from dynamicprompts.sampling_context import SamplingContext
 from dynamicprompts.sampling_result import SamplingResult

--- a/src/dynamicprompts/samplers/utils.py
+++ b/src/dynamicprompts/samplers/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from dynamicprompts.commands import VariantCommand, VariantOption, WildcardCommand
+from dynamicprompts.commands import Command, VariantCommand, VariantOption, WildcardCommand
 from dynamicprompts.parser.parse import parse
 from dynamicprompts.sampling_context import SamplingContext
 from dynamicprompts.sampling_result import SamplingResult
@@ -45,8 +45,11 @@ def get_wildcard_not_found_fallback(
     """
     Logs a warning, then infinitely yields the wrapped wildcard.
     """
-    logger.warning(f"No values found for wildcard {command.wildcard}")
-    wrapped_wildcard = context.wildcard_manager.to_wildcard(command.wildcard)
+    wildcard = command.wildcard
+    if isinstance(wildcard, Command):
+        wildcard = next(context.sample_prompts(wildcard, 1)).text
+    logger.warning(f"No values found for wildcard {wildcard}")
+    wrapped_wildcard = context.wildcard_manager.to_wildcard(wildcard)
     res = SamplingResult(text=wrapped_wildcard)
     while True:
         yield res

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -47,7 +47,7 @@ class TestParser:
         "input",
         [
             "colours",
-            "path/to/colours",           
+            "path/to/colours",
             "änder",
         ],
     )

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -89,6 +89,13 @@ class TestParser:
                     LiteralCommand("/furniture")
                 ]
             ),
+            (
+                "light/source/{indoor|outdoor}",
+                [
+                    LiteralCommand("light/source/"),
+                    VariantCommand.from_literals_and_weights(["indoor", "outdoor"])
+                ]
+            )
         ],
     )
     def test_wildcard_dynamic(self, input: str, expected_commands: list[Command]):

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -47,7 +47,7 @@ class TestParser:
         "input",
         [
             "colours",
-            "path/to/colours",            
+            "path/to/colours",
             "änder",
         ],
     )
@@ -59,43 +59,43 @@ class TestParser:
 
     @pytest.mark.parametrize(
         "input, expected_commands",
-        [            
+        [
             (
-                "path/to/${subject}", 
+                "path/to/${subject}",
                 [
                     LiteralCommand("path/to/"),
                     VariableAccessCommand("subject", LiteralCommand("subject")),
-                ]
+                ],
             ),
             (
-                "${pallette}_colours",  
+                "${pallette}_colours",
                 [
                     VariableAccessCommand("pallette", LiteralCommand("pallette")),
                     LiteralCommand("_colours"),
-                ]
+                ],
             ),
             (
-                "${pallette:warm}_colours",  
+                "${pallette:warm}_colours",
                 [
                     VariableAccessCommand("pallette", LiteralCommand("warm")),
                     LiteralCommand("_colours"),
-                ]
+                ],
             ),
             (
-                "locations/${room: dining room }/furniture", 
+                "locations/${room: dining room }/furniture",
                 [
                     LiteralCommand("locations/"),
                     VariableAccessCommand("room", LiteralCommand("dining room")),
-                    LiteralCommand("/furniture")
-                ]
+                    LiteralCommand("/furniture"),
+                ],
             ),
             (
                 "light/source/{indoor|outdoor}",
                 [
                     LiteralCommand("light/source/"),
-                    VariantCommand.from_literals_and_weights(["indoor", "outdoor"])
-                ]
-            )
+                    VariantCommand.from_literals_and_weights(["indoor", "outdoor"]),
+                ],
+            ),
         ],
     )
     def test_wildcard_dynamic(self, input: str, expected_commands: list[Command]):
@@ -104,7 +104,7 @@ class TestParser:
         assert isinstance(wildcard_command.wildcard, SequenceCommand)
         wildcard_sequence = cast(SequenceCommand, wildcard_command.wildcard)
         assert wildcard_sequence.tokens == expected_commands
-        assert wildcard_command.sampling_method is None    
+        assert wildcard_command.sampling_method is None
 
     @pytest.mark.parametrize(
         "input, sampling_method, wildcard",

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -47,7 +47,7 @@ class TestParser:
         "input",
         [
             "colours",
-            "path/to/colours",
+            "path/to/colours",            
             "änder",
         ],
     )
@@ -56,6 +56,48 @@ class TestParser:
         assert isinstance(wildcard_command, WildcardCommand)
         assert wildcard_command.wildcard == input
         assert wildcard_command.sampling_method is None
+
+    @pytest.mark.parametrize(
+        "input, expected_commands",
+        [            
+            (
+                "path/to/${subject}", 
+                [
+                    LiteralCommand("path/to/"),
+                    VariableAccessCommand("subject", LiteralCommand("subject")),
+                ]
+            ),
+            (
+                "${pallette}_colours",  
+                [
+                    VariableAccessCommand("pallette", LiteralCommand("pallette")),
+                    LiteralCommand("_colours"),
+                ]
+            ),
+            (
+                "${pallette:warm}_colours",  
+                [
+                    VariableAccessCommand("pallette", LiteralCommand("warm")),
+                    LiteralCommand("_colours"),
+                ]
+            ),
+            (
+                "locations/${room: dining room }/furniture", 
+                [
+                    LiteralCommand("locations/"),
+                    VariableAccessCommand("room", LiteralCommand("dining room")),
+                    LiteralCommand("/furniture")
+                ]
+            ),
+        ],
+    )
+    def test_wildcard_dynamic(self, input: str, expected_commands: list[Command]):
+        wildcard_command = parse(f"__{input}__")
+        assert isinstance(wildcard_command, WildcardCommand)
+        assert isinstance(wildcard_command.wildcard, SequenceCommand)
+        wildcard_sequence = cast(SequenceCommand, wildcard_command.wildcard)
+        assert wildcard_sequence.tokens == expected_commands
+        assert wildcard_command.sampling_method is None    
 
     @pytest.mark.parametrize(
         "input, sampling_method, wildcard",


### PR DESCRIPTION
This is actually a complete replacement of the work done in #110. This will replace the main source code added in that PR, but retain the test cases to ensure backwards compatibility. 

After trying to refactor #110 into a cleaner solution, I came to a better understanding of how the library was structured. The original solution supported variables, but seemed like a hack. 

The new solution updates wildcards to support either strings or Commands for the wildcard value. This now permits actual VariableAccessCommand or SequenceCommand instances as the value, which are resolved before resolving the wildcard. This new implementation also supports variants in the wildcard path. Wildcards of the form `__wildcard/${variable:default}__` and `__wildcard/{opt1|opt2|opt3}__` are now supported.