### PR TITLE
Loosen dependency pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = [
 
 [project.optional-dependencies]
 attentiongrabber = []  # empty list for backwards compatibility (no "no extra" warnings)
-magicprompt = ["transformers[torch]~=4.19"]
-feelinglucky = ["requests~=2.28"]
-yaml = ["pyyaml~=6.0"]
+magicprompt = ["transformers[torch]<5"]
+feelinglucky = ["requests<3"]
+yaml = ["pyyaml<7"]
 dev = [
     "pytest-cov~=4.0",
     "pytest-lazy-fixture~=0.6",


### PR DESCRIPTION
Refs https://github.com/adieyal/sd-dynamic-prompts/issues/743. 

We don't want the transitive `torch` dependency from an older version of `transformers` to try and install an older Torch.

I tested that magicprompts works fine with `transformers==4.39.0` – hopefully HF won't break things before version 5 of Transformers.