### PR TITLE
Improve parse error handling

### DIFF
--- a/src/dynamicprompts/parser/parse.py
+++ b/src/dynamicprompts/parser/parse.py
@@ -30,6 +30,7 @@ Note that whitespace is preserved in case it is significant to the user.
 
 from __future__ import annotations
 
+import logging
 import re
 from functools import partial
 from typing import Iterable
@@ -52,6 +53,8 @@ from dynamicprompts.commands.variable_commands import (
     VariableAssignmentCommand,
 )
 from dynamicprompts.parser.config import ParserConfig, default_parser_config
+
+logger = logging.getLogger(__name__)
 
 real_num1 = pp.Combine(pp.Word(pp.nums) + "." + pp.Word(pp.nums))
 real_num2 = pp.Combine(pp.Word(pp.nums) + ".")
@@ -554,10 +557,17 @@ def parse(
     if prompt.isalnum():  # no need to actually parse anything
         return LiteralCommand(prompt)
 
-    tokens = get_cached_parser(parser_config).parse_string(
-        prompt,
-        parse_all=True,
-    )
+    try:
+        tokens = get_cached_parser(parser_config).parse_string(
+            prompt,
+            parse_all=True,
+        )
+    except pp.ParseException as fe:
+        logger.warning(
+            "Dynamic Prompts: PyParsing error:\n%s\n---",
+            fe.explain(depth=0),
+        )
+        raise
     if len(tokens) != 1:
         raise ValueError(f"Could not parse prompt {prompt!r}")
 

--- a/src/dynamicprompts/parser/parse.py
+++ b/src/dynamicprompts/parser/parse.py
@@ -574,3 +574,22 @@ def parse(
     tok = tokens[0]
     assert isinstance(tok, Command)
     return tok
+
+
+def try_parse(
+    prompt: str,
+    parser_config: ParserConfig = default_parser_config,
+) -> Command:
+    """
+    Try to parse a prompt string into a command, returning a LiteralCommand
+    if parsing fails.
+
+    :param prompt: The prompt string to parse.
+    :param parser_config: The parser configuration to use.
+    :return: A command representing the parsed prompt.
+    """
+    try:
+        return parse(prompt, parser_config=parser_config)
+    except pp.ParseException:
+        # The error will have been logged by `parse()`.
+        return LiteralCommand(prompt)

--- a/src/dynamicprompts/samplers/utils.py
+++ b/src/dynamicprompts/samplers/utils.py
@@ -8,7 +8,7 @@ from dynamicprompts.commands import (
     VariantOption,
     WildcardCommand,
 )
-from dynamicprompts.parser.parse import parse
+from dynamicprompts.parser.parse import try_parse
 from dynamicprompts.sampling_context import SamplingContext
 from dynamicprompts.sampling_result import SamplingResult
 from dynamicprompts.types import ResultGen
@@ -30,7 +30,7 @@ def wildcard_to_variant(
     max_bound = min(max_bound, len(values))
 
     variant_options = [
-        VariantOption(parse(v, parser_config=context.parser_config))
+        VariantOption(try_parse(v, parser_config=context.parser_config))
         for v in values.iterate_string_values_weighted()
     ]
 

--- a/src/dynamicprompts/wildcards/wildcard_manager.py
+++ b/src/dynamicprompts/wildcards/wildcard_manager.py
@@ -49,6 +49,20 @@ class WildcardManager:
         elif self._path:
             self._root_map = {"": [self._path]}
 
+    @classmethod
+    def from_map(
+        cls,
+        map: dict[str, WildcardCollection],
+        *,
+        wildcard_wrap=default_parser_config.wildcard_wrap,
+    ) -> WildcardManager:
+        """
+        Build a WildcardManager from a map of paths to WildcardCollections.
+        """
+        manager = cls(wildcard_wrap=wildcard_wrap)
+        manager._tree = WildcardTree.from_map(map)
+        return manager
+
     @property
     def sort_wildcards(self) -> bool:
         """


### PR DESCRIPTION
* Log the Pyparsing `explain()` context for a parse failure
* Don't fail entire parsing if a wildcard value is not parseable

Refs https://github.com/adieyal/sd-dynamic-prompts/issues/572