### PR TITLE
Added new Jinja helper functions `flip_coin` and `pick_multiple`

### DIFF
--- a/src/dynamicprompts/jinja_extensions.py
+++ b/src/dynamicprompts/jinja_extensions.py
@@ -22,6 +22,20 @@ def weighted_choice(*items) -> Any:
     return random.choices(population, weights=weights)[0]
 
 
+def flip_coin(first_result = True, second_result = False) -> bool:
+    return random.choice([first_result, second_result])
+
+
+def pick_multiple(items: Iterable[Any], returnLength: int | True = True) -> list[Any]:
+    if returnLength is True:
+        returnLength = random.randint(1, len(items))
+    if returnLength == 0:
+        return []
+    if returnLength > len(items):
+        return list(items)
+    return random.sample(list(items), returnLength)
+
+
 def permutation(
     items: Iterable[Any],
     low: int,
@@ -98,6 +112,8 @@ class PromptExtension(Extension):
 DYNAMICPROMPTS_FUNCTIONS: dict[str, Any] = {
     "choice": choice,
     "weighted_choice": weighted_choice,
+    "flip_coin": flip_coin,
+    "pick_multiple": pick_multiple,
     "random": random.random,
     "randint": random.randint,
     "permutations": permutation,


### PR DESCRIPTION
I added two new helper functions for Jinja2 templates.

## `pick_multiple`

Returns multiple values from an input list (a resolved wildcard for example). The number of items can be specified, otherwise it’s rolled between 1 and the maximum. If the specified amount is too high, it’s autocorrected instead of throwing an error.

### Example

#### Between 1 and maximum
```jinja2
{% set separator = ' and ' %}
{% set characters = ['ash', 'misty', 'brock', 'professor_oak', 'gary'] %}
a hike with {{ pick_multiple(characters)|join(separator) }} in the mountains
```

#### Between 0 and maximum

```jinja2
{% set separator = ' and ' %}
a hike
{% set characters = ['ash', 'misty', 'brock', 'professor_oak', 'gary'] %}
{% set charactersAmount = randint(0, characters|length) %}
{% if charactersAmount > 0 %}
  with {{ pick_multiple(characters, charactersAmount)|join(separator) }}
{% endif %}
in the mountains
```

## `flip_coin`

If no arguments are given, returns a random boolean. Otherwise randomly picks an argument.

### Example

#### For branches
```jinja2
{% if flip_coin() %}
  1girl,
{% endif %}
laying on grass
```

#### For quick inline decisions
```jinja2
a {{ flip_coin('caught', 'fleeing') }} Pikachu
```