### PR TITLE
Specify loader for jinja template (external Jinja template support)

### DIFF
--- a/src/dynamicprompts/generators/jinjagenerator.py
+++ b/src/dynamicprompts/generators/jinjagenerator.py
@@ -69,10 +69,11 @@ class JinjaGenerator(PromptGenerator):
             PromptExtension,
         )
 
-        env = jinja2.Environment(
-            extensions=[PromptExtension],
-            loader=jinja2.FileSystemLoader(self._wildcard_manager.path)
-        )
+        env_kwargs = dict(extensions=[PromptExtension])
+        # If wildcard root is specified, set it as jinja template root, also
+        if self._wildcard_manager.path:
+           env_kwargs.update(loader=jinja2.FileSystemLoader(self._wildcard_manager.path))
+        env = jinja2.Environment(**env_kwargs)
         prompt_blocks: list[str] = []
         env.globals.update(
             {

--- a/src/dynamicprompts/generators/jinjagenerator.py
+++ b/src/dynamicprompts/generators/jinjagenerator.py
@@ -69,7 +69,10 @@ class JinjaGenerator(PromptGenerator):
             PromptExtension,
         )
 
-        env = jinja2.Environment(extensions=[PromptExtension])
+        env = jinja2.Environment(
+            extensions=[PromptExtension],
+            loader=jinja2.FileSystemLoader(self._wildcard_manager.path)
+        )
         prompt_blocks: list[str] = []
         env.globals.update(
             {

--- a/tests/generators/test_jinja.py
+++ b/tests/generators/test_jinja.py
@@ -280,3 +280,23 @@ class TestJinjaGenerator:
         prompts = generator.generate(template)
         for p in prompts:
             assert "\n" not in p
+
+    def test_jinja_template_from_file(self, generator: JinjaGenerator):
+        template = """
+        {%- import 'jinja/lib.jinja' as lib -%}
+        {{ lib.echo('test') -}}
+        """
+        assert generator.generate(template) == ["test"]
+
+        with patch("random.choice") as mock_choice:
+            mock_choice.side_effect = ["red", "blue", "red"]
+            template = """
+            {%- import 'jinja/lib.jinja' as lib with context -%}
+            {{ lib.mychoice() -}}
+            """
+
+            assert generator.generate(template, 3) == [
+                "This is a red rose",
+                "This is a blue rose",
+                "This is a red rose",
+            ]

--- a/tests/test_data/wildcards/jinja/lib.jinja
+++ b/tests/test_data/wildcards/jinja/lib.jinja
@@ -1,0 +1,6 @@
+{% macro echo(arg) -%}
+{{ arg }}
+{%- endmacro %}
+{% macro mychoice() -%}
+This is a {{ choice('red', 'blue') }} rose
+{%- endmacro %}


### PR DESCRIPTION
Jinja templates have great potential for building complex prompts.
However, they are currently limited within a prompt.
Enabling the use of external Jinja templates via import/include features could open up another level of possibilities.

This PR provides a straightforward implementation to share Jinja templates using a wildcard folder.

Some considerations include:
- It might be better to assign a dedicated Jinja template folder.
- It might be better to add configuration options to enable/disable this feature.