### PR TITLE
Update docs to reflect #113.

### DIFF
--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -329,11 +329,12 @@ artists:
     - Piet Mondrian
     - Rembrandt van Rijn
     - Vincent van Gogh
+  italian: Leonardo da Vinci # this is valid: treated as a collection of one item
   1234: 5678  # this is ignored
   flurp: 12345  # this too
 ```
 
-The last two entries are ignore since they don't store arrays.
+The last two entries are ignored since their values are numeric scalars. However, the entry of `italian` (on the third line from the bottom) is valid. A single string is parsed as a single-item collection.
 
 ##### Weighted options in YAML
 


### PR DESCRIPTION
By https://github.com/adieyal/dynamicprompts/pull/113, single strings are parsed as collections of one item in structured wildcard files. However, the documentation has not yet been updated to reflect this change.

This pull request updates the documentation.

https://github.com/adieyal/dynamicprompts/blob/58815af851848fdfd0ed89e18c483dd37eb2a9b1/docs/SYNTAX.md?plain=1#L332

```
# snip
  1234: 5678  # this is ignored
  flurp: 12345  # this too
```

>The last two entries are ignore since they don't store arrays.

The comments themselves are correct, but the reason why they are ignored becomes they are numeric scalars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated YAML wildcard syntax documentation with clarified examples and explanations regarding how string and numeric scalar entries are handled in collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->